### PR TITLE
Add --declarations-starting-version arg to prepare-release

### DIFF
--- a/.github/actions/prepare-release/action.yml
+++ b/.github/actions/prepare-release/action.yml
@@ -8,6 +8,10 @@ inputs:
   repository_url:
     description: The URL of the repository (e.g.; https://github.com/octocat/Hello-World)
     default: https://github.com/${{ github.repository }}
+    required: false
+  declarations_starting_version:
+    description: When generating markdown declarations for each release, what version should be the start
+    required: false
 
 outputs:
   from_version:

--- a/.github/actions/prepare-release/index.js
+++ b/.github/actions/prepare-release/index.js
@@ -1,5 +1,5 @@
 require('../../bootstrap').invokeWith(({ getInput }) => {
-    return [
+    const args = [
         'prepare-release',
 
         '--bump',
@@ -8,4 +8,12 @@ require('../../bootstrap').invokeWith(({ getInput }) => {
         '--repository-url',
         getInput('repository_url')
     ]
+
+    const declarationsStartingVersion = getInput('declarations_starting_version')
+    if (declarationsStartingVersion) {
+        args.push('--declarations-starting-version')
+        args.push(declarationsStartingVersion)
+    }
+
+    return args
 })

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,7 @@ dependencies = [
  "markdown",
  "rand",
  "regex",
+ "semver",
  "serde",
  "serde_json",
  "toml_edit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ libcnb-package = "0.13.0"
 markdown = "1.0.0-alpha.10"
 rand = "0.8.5"
 regex = "1.8.3"
+semver = "1.0.17"
 serde = { version = "1.0.164", features = ["derive"] }
 serde_json = "1.0.97"
 toml_edit = "0.19.10"

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ A set of custom GitHub Actions and reusable workflow used by the Languages Team.
 
 This action generates a list of buildpack `id` and `path` values.  E.g.;
 
-```json
+```js
 [
   {
     "id": "some/buildpack-id",
     "path": "/path/to/some/buildpack"
   },
-  ...
+  // ...
 ]
 ```
 
@@ -79,10 +79,11 @@ You can also pin to a [specific release](/releases) version in the format `@v{ma
 
 #### Inputs
 
-| Name             | Description                                                              | Required | Default                                       |
-|------------------|--------------------------------------------------------------------------|----------|-----------------------------------------------|
-| `bump`           | Which coordinate should be incremented? (major, minor, patch)            | true     |                                               |
-| `repository_url` | The URL of the repository (e.g.; https://github.com/octocat/Hello-World) | false    | `https://github.com/${{ github.repository }}` |
+| Name                            | Description                                                                              | Required | Default                                       |
+|---------------------------------|------------------------------------------------------------------------------------------|----------|-----------------------------------------------|
+| `bump`                          | Which coordinate should be incremented? (major, minor, patch)                            | true     |                                               |
+| `repository_url`                | The URL of the repository (e.g.; https://github.com/octocat/Hello-World)                 | false    | `https://github.com/${{ github.repository }}` |
+| `declarations_starting_version` | When generating markdown declarations for each release, what version should be the start | false    |                                               |
 
 #### Outputs
 
@@ -111,7 +112,7 @@ You can also pin to a [specific release](/releases) version in the format `@v{ma
 | `buildpack_id`      | The id of the buildpack                              | true     |                    |
 | `buildpack_version` | The version of the buildpack                         | true     |                    |
 | `buildpack_uri`     | The URI of the published buildpack                   | true     |                    |
-| `builders`          | A comma-separated list of builders to update         | true     |                    | 
+| `builders`          | A comma-separated list of builders to update         | true     |                    |
 | `path`              | Relative path under `GITHUB_WORKSPACE` to execute in | false    | `GITHUB_WORKSPACE` |
 
 ## Development
@@ -130,17 +131,17 @@ Commands:
   help                       Print this message or the help of the given subcommand(s)
 ```
 
-This `actions` command is bootstraped into the GitHub Action environment using the script found at 
+This `actions` command is bootstraped into the GitHub Action environment using the script found at
 [`.github/bootstrap/bootstrap.ts`](.github/bootstrap/bootstrap.ts) which attempts to download this command from this
 repository's [releases](/releases) page.
 
-> **Note** 
-> 
-> Any changes made to this bootstrap script will need to be recompiled by running `npm run build` and committing the bundled 
+> **Note**
+>
+> Any changes made to this bootstrap script will need to be recompiled by running `npm run build` and committing the bundled
 > script into GitHub. You'll need Node and NPM installed to do this.
 
-Each of the custom actions must import this bootstrap script to obtain access to the `actions` command line application and 
-then it must provide a list of arguments to invoke the target action.  
+Each of the custom actions must import this bootstrap script to obtain access to the `actions` command line application and
+then it must provide a list of arguments to invoke the target action.
 
 For example, this would invoke `actions generate-buildpack-matrix`:
 

--- a/src/commands/prepare_release/errors.rs
+++ b/src/commands/prepare_release/errors.rs
@@ -5,12 +5,12 @@ use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 use std::io;
 use std::path::PathBuf;
-use uriparse::URIError;
 
 #[derive(Debug)]
 pub(crate) enum Error {
     GetCurrentDir(io::Error),
-    InvalidRepositoryUrl(String, URIError),
+    InvalidRepositoryUrl(String, uriparse::URIError),
+    InvalidDeclarationsStartingVersion(String, semver::Error),
     NoBuildpacksFound(PathBuf),
     NotAllVersionsMatch(HashMap<PathBuf, BuildpackVersion>),
     NoFixedVersion,
@@ -35,7 +35,14 @@ impl Display for Error {
             }
 
             Error::InvalidRepositoryUrl(value, error) => {
-                write!(f, "Invalid URL `{value}`\nError: {error}")
+                write!(
+                    f,
+                    "Invalid URL `{value}` for argument --repository-url\nError: {error}"
+                )
+            }
+
+            Error::InvalidDeclarationsStartingVersion(value, error) => {
+                write!(f, "Invalid Version `{value}` for argument --declarations-starting-version\nError: {error}")
             }
 
             Error::NoBuildpacksFound(path) => {


### PR DESCRIPTION
The optional argument `--declarations-starting-version` has been added to the `actions prepare-release` command to limit the declarations created when rebuilding the `CHANGELOG.md` file into the Keep A Changelog format.

Buildpacks that are only now normalizing on fixed versions and release tags (e.g.; [`buildpacks-jvm`](https://github.com/heroku/buildpacks-jvm), [`buildpacks-nodejs`](https://github.com/heroku/buildpacks-nodejs)) can use this to prevent invalid declaration links from being generated.