### PR TITLE
Strip the release binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ publish = false
 name = "actions"
 path = "src/main.rs"
 
+[profile.release]
+strip = true
+
 [dependencies]
 chrono = "0.4.26"
 clap = { version = "4.3.5", default-features = false, features = [


### PR DESCRIPTION
Before:

```
$ ls -lh target/release/actions
-rwxr-xr-x 1 emorley staff 4.1M Jun 22 09:59 target/release/actions
```

After:

```
$ ls -lh target/release/actions
-rwxr-xr-x 1 emorley staff 3.0M Jun 22 10:01 target/release/actions
```

See:
https://doc.rust-lang.org/stable/cargo/reference/profiles.html#strip