### PR TITLE
Fix update builder workflow branch name

### DIFF
--- a/.github/workflows/_buildpacks-release-update-builder.yml
+++ b/.github/workflows/_buildpacks-release-update-builder.yml
@@ -56,9 +56,9 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ steps.generate-token.outputs.app_token }}
-          title: Update ${{ github.repository }} to v${{ steps.buildpack.outputs.buildpack_version }}
+          title: Update ${{ github.repository }}
           path: ./builder
-          branch: update/${{ github.repository }}/${{ steps.buildpack.outputs.buildpack_version }}
+          branch: update/${{ github.repository }}
           body-path: ${{ steps.buildpack.outputs.changes_file }}
 
       - name: Configure PR


### PR DESCRIPTION
Drops the version from the branch created. We don't have that information here not that it isn't run with as part of a strategy.