### PR TITLE
Only run actions against buildpacks that also contain a CHANGELOG.md

### DIFF
--- a/src/buildpacks.rs
+++ b/src/buildpacks.rs
@@ -1,5 +1,6 @@
 use libcnb_data::buildpack::BuildpackDescriptor;
-use libcnb_package::GenericMetadata;
+use libcnb_package::{find_buildpack_dirs, GenericMetadata};
+use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus};
 
 #[derive(Debug)]
@@ -38,4 +39,13 @@ pub(crate) fn read_docker_repository_metadata(
         .and_then(|release| release.get("docker").and_then(|value| value.as_table()))
         .and_then(|docker| docker.get("repository").and_then(|value| value.as_str()))
         .map(|value| value.to_string())
+}
+
+pub(crate) fn find_releasable_buildpacks(starting_dir: &Path) -> std::io::Result<Vec<PathBuf>> {
+    find_buildpack_dirs(starting_dir, &[starting_dir.join("target")]).map(|results| {
+        results
+            .into_iter()
+            .filter(|dir| dir.join("CHANGELOG.md").exists())
+            .collect()
+    })
 }

--- a/src/commands/generate_buildpack_matrix/command.rs
+++ b/src/commands/generate_buildpack_matrix/command.rs
@@ -1,8 +1,8 @@
-use crate::buildpacks::read_docker_repository_metadata;
+use crate::buildpacks::{find_releasable_buildpacks, read_docker_repository_metadata};
 use crate::commands::generate_buildpack_matrix::errors::Error;
 use crate::github::actions;
 use clap::Parser;
-use libcnb_package::{find_buildpack_dirs, read_buildpack_data, BuildpackData, GenericMetadata};
+use libcnb_package::{read_buildpack_data, BuildpackData, GenericMetadata};
 use std::collections::{BTreeMap, HashSet};
 use std::path::Path;
 
@@ -15,7 +15,7 @@ pub(crate) struct GenerateBuildpackMatrixArgs;
 pub(crate) fn execute(_: GenerateBuildpackMatrixArgs) -> Result<()> {
     let current_dir = std::env::current_dir().map_err(Error::GetCurrentDir)?;
 
-    let buildpack_dirs = find_buildpack_dirs(&current_dir, &[current_dir.join("target")])
+    let buildpack_dirs = find_releasable_buildpacks(&current_dir)
         .map_err(|e| Error::FindingBuildpacks(current_dir.clone(), e))?;
 
     let buildpacks = buildpack_dirs

--- a/src/commands/generate_changelog/command.rs
+++ b/src/commands/generate_changelog/command.rs
@@ -1,9 +1,10 @@
+use crate::buildpacks::find_releasable_buildpacks;
 use crate::changelog::Changelog;
 use crate::commands::generate_changelog::errors::Error;
 use crate::github::actions;
 use clap::Parser;
 use libcnb_data::buildpack::BuildpackId;
-use libcnb_package::{find_buildpack_dirs, read_buildpack_data};
+use libcnb_package::read_buildpack_data;
 use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 
@@ -29,7 +30,7 @@ pub(crate) fn execute(args: GenerateChangelogArgs) -> Result<()> {
     let working_dir =
         get_working_dir_from(args.path.map(PathBuf::from)).map_err(Error::GetWorkingDir)?;
 
-    let buildpack_dirs = find_buildpack_dirs(&working_dir, &[working_dir.join("target")])
+    let buildpack_dirs = find_releasable_buildpacks(&working_dir)
         .map_err(|e| Error::FindingBuildpacks(working_dir.clone(), e))?;
 
     let changelog_entry_type = match args.version {

--- a/src/commands/prepare_release/command.rs
+++ b/src/commands/prepare_release/command.rs
@@ -1,3 +1,4 @@
+use crate::buildpacks::find_releasable_buildpacks;
 use crate::changelog::{generate_release_declarations, Changelog, ReleaseEntry};
 use crate::commands::prepare_release::errors::Error;
 use crate::github::actions;
@@ -5,7 +6,6 @@ use chrono::{DateTime, Utc};
 use clap::{Parser, ValueEnum};
 use indexmap::IndexMap;
 use libcnb_data::buildpack::{BuildpackId, BuildpackVersion};
-use libcnb_package::find_buildpack_dirs;
 use semver::Version;
 use std::collections::{HashMap, HashSet};
 use std::fs::write;
@@ -65,7 +65,7 @@ pub(crate) fn execute(args: PrepareReleaseArgs) -> Result<()> {
         })
         .transpose()?;
 
-    let buildpack_dirs = find_buildpack_dirs(&current_dir, &[current_dir.join("target")])
+    let buildpack_dirs = find_releasable_buildpacks(&current_dir)
         .map_err(|e| Error::FindingBuildpacks(current_dir.clone(), e))?;
 
     if buildpack_dirs.is_empty() {

--- a/src/commands/update_builder/command.rs
+++ b/src/commands/update_builder/command.rs
@@ -1,8 +1,10 @@
-use crate::buildpacks::{calculate_digest, read_docker_repository_metadata};
+use crate::buildpacks::{
+    calculate_digest, find_releasable_buildpacks, read_docker_repository_metadata,
+};
 use crate::update_builder::errors::Error;
 use clap::Parser;
 use libcnb_data::buildpack::{BuildpackId, BuildpackVersion};
-use libcnb_package::{find_buildpack_dirs, read_buildpack_data};
+use libcnb_package::read_buildpack_data;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use toml_edit::{value, Document};
@@ -32,7 +34,7 @@ pub(crate) fn execute(args: UpdateBuilderArgs) -> Result<()> {
     let builder_repository_path =
         resolve_path(PathBuf::from(args.builder_repository_path), &current_dir);
 
-    let buildpacks = find_buildpack_dirs(&repository_path, &[repository_path.join("target")])
+    let buildpacks = find_releasable_buildpacks(&repository_path)
         .map_err(|e| Error::FindingBuildpacks(current_dir.clone(), e))?
         .into_iter()
         .map(|dir| read_buildpack_data(dir).map_err(Error::ReadingBuildpackData))


### PR DESCRIPTION
All of our buildpacks should be following the Keep-a-Changelog format so filtering detected buildpacks by directories that contain both `buildpack.toml` and `CHANGELOG.md` seems like a sensible choice.

This also eliminates some of the extra buildpack directories that are being picked up in [`heroku/buildpacks-nodejs`](https://github.com/heroku/buildpacks-nodejs).