### PR TITLE
Enable additional rustc/Clippy lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,6 @@ dependencies = [
  "rand",
  "regex",
  "semver",
- "serde",
  "serde_json",
  "toml_edit",
  "uriparse",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ markdown = "1.0.0-alpha.10"
 rand = "0.8.5"
 regex = "1.8.3"
 semver = "1.0.17"
-serde = { version = "1.0.164", features = ["derive"] }
 serde_json = "1.0.99"
 toml_edit = "0.19.11"
 uriparse = "0.6.4"

--- a/src/buildpacks.rs
+++ b/src/buildpacks.rs
@@ -33,6 +33,7 @@ pub(crate) fn read_docker_repository_metadata(
         BuildpackDescriptor::Meta(descriptor) => &descriptor.metadata,
     };
 
+    #[allow(clippy::redundant_closure_for_method_calls)]
     metadata
         .as_ref()
         .and_then(|metadata| metadata.get("release").and_then(|value| value.as_table()))

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -46,7 +46,7 @@ impl TryFrom<&str> for Changelog {
                         Ordering::Less => {
                             current_header = None;
                         }
-                        _ => {
+                        Ordering::Greater => {
                             if let Some(header) = &current_header {
                                 let body_nodes = body_nodes_by_header
                                     .entry(header.clone())
@@ -115,8 +115,8 @@ impl TryFrom<&str> for Changelog {
                         version.to_string(),
                         ReleaseEntry {
                             version,
-                            body,
                             date,
+                            body,
                         },
                     );
                 }
@@ -254,7 +254,7 @@ pub(crate) fn generate_release_declarations<S: Into<String>>(
                 "[{version}]: {repository}/compare/v{next_version}...v{version}"
             ));
         }
-        previous_version = Some(next_version)
+        previous_version = Some(next_version);
     }
 
     if let Some(version) = previous_version {
@@ -268,7 +268,7 @@ pub(crate) fn generate_release_declarations<S: Into<String>>(
 mod test {
     use crate::changelog::{generate_release_declarations, Changelog};
     use chrono::{TimeZone, Utc};
-    use semver::Version;
+    use semver::{BuildMetadata, Prerelease, Version};
 
     #[test]
     fn test_keep_a_changelog_unreleased_entry_with_changes_parsing() {
@@ -318,7 +318,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated function runtime to 1.0.3
 "
-        )
+        );
     }
 
     #[test]
@@ -482,8 +482,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
                 major: 1,
                 minor: 0,
                 patch: 0,
-                pre: Default::default(),
-                build: Default::default(),
+                pre: Prerelease::default(),
+                build: BuildMetadata::default(),
             }),
         );
         assert_eq!(

--- a/src/commands/generate_changelog/command.rs
+++ b/src/commands/generate_changelog/command.rs
@@ -45,7 +45,7 @@ pub(crate) fn execute(args: GenerateChangelogArgs) -> Result<()> {
                 .map_err(Error::GetBuildpackId)
                 .map(|data| data.buildpack_descriptor.buildpack().id.clone())
                 .and_then(|buildpack_id| {
-                    read_changelog_entry(dir.join("CHANGELOG.md"), &changelog_entry_type)
+                    read_changelog_entry(&dir.join("CHANGELOG.md"), &changelog_entry_type)
                         .map(|contents| (buildpack_id, contents))
                 })
         })
@@ -59,11 +59,11 @@ pub(crate) fn execute(args: GenerateChangelogArgs) -> Result<()> {
 }
 
 fn read_changelog_entry(
-    path: PathBuf,
+    path: &PathBuf,
     changelog_entry_type: &ChangelogEntryType,
 ) -> Result<Option<Option<String>>> {
     let contents =
-        std::fs::read_to_string(&path).map_err(|e| Error::ReadingChangelog(path.clone(), e))?;
+        std::fs::read_to_string(path).map_err(|e| Error::ReadingChangelog(path.clone(), e))?;
     let changelog = Changelog::try_from(contents.as_str())
         .map_err(|e| Error::ParsingChangelog(path.clone(), e))?;
     Ok(match changelog_entry_type {
@@ -142,6 +142,6 @@ mod test {
 - No changes
 
 "#
-        )
+        );
     }
 }

--- a/src/commands/generate_changelog/command.rs
+++ b/src/commands/generate_changelog/command.rs
@@ -58,6 +58,7 @@ pub(crate) fn execute(args: GenerateChangelogArgs) -> Result<()> {
     Ok(())
 }
 
+#[allow(clippy::option_option)]
 fn read_changelog_entry(
     path: &PathBuf,
     changelog_entry_type: &ChangelogEntryType,
@@ -89,6 +90,7 @@ fn get_working_dir_from(path: Option<PathBuf>) -> std::io::Result<PathBuf> {
     })
 }
 
+#[allow(clippy::option_option)]
 fn generate_changelog(
     changes_by_buildpack: &HashMap<BuildpackId, Option<Option<String>>>,
 ) -> String {

--- a/src/commands/prepare_release/errors.rs
+++ b/src/commands/prepare_release/errors.rs
@@ -28,27 +28,24 @@ pub(crate) enum Error {
 }
 
 impl Display for Error {
+    #[allow(clippy::too_many_lines)]
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Error::GetCurrentDir(error) => {
                 write!(f, "Failed to get current directory\nError: {error}")
             }
-
             Error::InvalidRepositoryUrl(value, error) => {
                 write!(
                     f,
                     "Invalid URL `{value}` for argument --repository-url\nError: {error}"
                 )
             }
-
             Error::InvalidDeclarationsStartingVersion(value, error) => {
                 write!(f, "Invalid Version `{value}` for argument --declarations-starting-version\nError: {error}")
             }
-
             Error::NoBuildpacksFound(path) => {
                 write!(f, "No buildpacks found under {}", path.display())
             }
-
             Error::NotAllVersionsMatch(version_map) => {
                 write!(
                     f,
@@ -60,11 +57,9 @@ impl Display for Error {
                         .join("\n")
                 )
             }
-
             Error::NoFixedVersion => {
                 write!(f, "No fixed version could be determined")
             }
-
             Error::FindingBuildpacks(path, error) => {
                 write!(
                     f,
@@ -86,7 +81,6 @@ impl Display for Error {
                     path.display()
                 )
             }
-
             Error::WritingBuildpack(path, error) => {
                 write!(
                     f,
@@ -94,7 +88,6 @@ impl Display for Error {
                     path.display()
                 )
             }
-
             Error::ReadingChangelog(path, error) => {
                 write!(
                     f,
@@ -102,7 +95,6 @@ impl Display for Error {
                     path.display()
                 )
             }
-
             Error::ParsingChangelog(path, error) => {
                 write!(
                     f,
@@ -110,7 +102,6 @@ impl Display for Error {
                     path.display()
                 )
             }
-
             Error::WritingChangelog(path, error) => {
                 write!(
                     f,
@@ -118,13 +109,11 @@ impl Display for Error {
                     path.display()
                 )
             }
-
             Error::SetActionOutput(set_output_error) => match set_output_error {
                 SetOutputError::Opening(error) | SetOutputError::Writing(error) => {
                     write!(f, "Could not write action output\nError: {error}")
                 }
             },
-
             Error::MissingRequiredField(path, field) => {
                 write!(
                     f,
@@ -132,7 +121,6 @@ impl Display for Error {
                     path.display()
                 )
             }
-
             Error::InvalidBuildpackId(path, id) => {
                 write!(
                     f,
@@ -140,7 +128,6 @@ impl Display for Error {
                     path.display()
                 )
             }
-
             Error::InvalidBuildpackVersion(path, version) => {
                 write!(
                     f,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,6 @@
+#![warn(clippy::pedantic)]
+#![warn(unused_crate_dependencies)]
+
 use crate::commands::generate_buildpack_matrix::command::GenerateBuildpackMatrixArgs;
 use crate::commands::generate_changelog::command::GenerateChangelogArgs;
 use crate::commands::prepare_release::command::PrepareReleaseArgs;


### PR DESCRIPTION
Most of the changes were generated by `cargo clippy --fix`.

I've added a temporary `allow(clippy::option_option)` since resolving that lint error will require a refactor, so worth handling separately.

Fixes #36.
GUS-W-13664629.