### PR TITLE
Remove setup-tools step from package workflow

### DIFF
--- a/.github/workflows/_buildpacks-release-package.yml
+++ b/.github/workflows/_buildpacks-release-package.yml
@@ -47,9 +47,6 @@ jobs:
       - name: Install Pack CLI
         uses: buildpacks/github-actions/setup-pack@v5.2.0
 
-      - name: Install yj
-        uses: buildpacks/github-actions/setup-tools@v5.2.0
-
       - name: Install libcnb-cargo
         run: cargo install libcnb-cargo
 


### PR DESCRIPTION
The `setup-tools` step was previously used to install `yj` and extract metadata from the buildpack during the `package` workflow but this is no longer required since that metadata is now extracted as part of the `detect` workflow.

@fixes #51