### PR TITLE
Enable colorized cargo output

### DIFF
--- a/.github/workflows/_buildpacks-release-package.yml
+++ b/.github/workflows/_buildpacks-release-package.yml
@@ -21,6 +21,9 @@ on:
 permissions:
   contents: read
 
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
   release-package:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Sets the `CARGO_TERM_COLOR` environment variable in the `package` workflow so we get colorized output from `cargo` commands.

@fixes #52