### PR TITLE
Improve the UX for GHA cache restore timeout errors

### DIFF
--- a/.github/actions/restore-buildpack-release/action.yml
+++ b/.github/actions/restore-buildpack-release/action.yml
@@ -23,10 +23,11 @@ runs:
     - name: Restore cached assets
       uses: actions/cache/restore@v3
       with:
+        fail-on-cache-miss: true
         key: ${{ github.run_id }}-${{ inputs.buildpack_artifact_prefix }}
         path: |
           ${{ inputs.buildpack_artifact_prefix }}.cnb
           ${{ inputs.buildpack_artifact_prefix }}.tar.zst
           ${{ inputs.buildpack_artifact_prefix }}.changes
-
-
+      env:
+        SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1


### PR DESCRIPTION
Previously if any of the cache restore steps failed due to a timeout, the restore step would only emit a warning, and then the job would continue onto later steps that will fail if the restored files don't exist.

Now:
* If the cache cannot be restored, the cache restore step itself will correctly fail (since we need the restored files).
* The timeout has also been reduced from 10 minutes to 1 minute, so the job fails (and can be retried) sooner.

See:
https://github.com/actions/cache/tree/main/restore

This is a port of the improvements in:
https://github.com/heroku/builder/pull/360

Fixes #61.
GUS-W-13738824.