### PR TITLE
Set commit message on PR to heroku/builder

### DIFF
--- a/.github/workflows/_buildpacks-release-update-builder.yml
+++ b/.github/workflows/_buildpacks-release-update-builder.yml
@@ -66,6 +66,7 @@ jobs:
         with:
           token: ${{ steps.generate-token.outputs.app_token }}
           title: Update ${{ github.repository }} to v${{ inputs.buildpack_version }}
+          commit-message: Update ${{ github.repository }} to v${{ inputs.buildpack_version }}
           path: ./builder
           branch: update/${{ github.repository }}/${{ inputs.buildpack_version }}
           body: ${{ steps.generate-changelog.outputs.changelog }}


### PR DESCRIPTION
This will replace the default `[create-pull-request] automated change` commit message with the details of what is actually in the commit.

Fixes #50, [GUS:W-13738729](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001Vs0bqYAB/view)