### PR TITLE
Update to request-add-entry action v5.3.0

### DIFF
--- a/.github/workflows/_buildpacks-release-publish-cnb-registry.yml
+++ b/.github/workflows/_buildpacks-release-publish-cnb-registry.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Register the new version with the CNB Buildpack Registry
         if: steps.check.outputs.published_to_cnb_registry == 'false'
-        uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:5.0.1
+        uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:5.3.0
         with:
           token: ${{ secrets.cnb_registry_token }}
           id: ${{ inputs.buildpack_id }}


### PR DESCRIPTION
Dependabot can currently only update standard actions, not those that use a Docker Hub reference - so this Docker Hub reference has to be updated manually.

The upstream `request-add-entry` action has a number of fixes we should pick up:
https://github.com/buildpacks/github-actions/compare/v5.0.1...v5.3.0

Most notably:
- https://github.com/buildpacks/github-actions/pull/198
- https://github.com/buildpacks/github-actions/pull/214

Fixes #68.
GUS-W-13788681.