### PR TITLE
Pin third-party GitHub Actions to specific patch versions

### DIFF
--- a/.github/workflows/_buildpacks-prepare-release.yml
+++ b/.github/workflows/_buildpacks-prepare-release.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Create pull request
         id: pr
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v5.0.2
         with:
           token: ${{ steps.generate-token.outputs.app_token }}
           title: Prepare release v${{ steps.prepare.outputs.to_version }}

--- a/.github/workflows/_buildpacks-release-package.yml
+++ b/.github/workflows/_buildpacks-release-package.yml
@@ -45,7 +45,7 @@ jobs:
         run: rustup target add x86_64-unknown-linux-musl
 
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@v2.5.1
 
       - name: Install Pack CLI
         uses: buildpacks/github-actions/setup-pack@v5.3.0

--- a/.github/workflows/_buildpacks-release-publish-docker.yml
+++ b/.github/workflows/_buildpacks-release-publish-docker.yml
@@ -43,7 +43,7 @@ jobs:
         run: zstd -dc --long=31 ${{ steps.artifacts.outputs.docker_image }} | docker load
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v2.2.0
         with:
           registry: docker.io
           username: ${{ secrets.docker_hub_user }}

--- a/.github/workflows/_buildpacks-release-publish-github.yml
+++ b/.github/workflows/_buildpacks-release-publish-github.yml
@@ -25,7 +25,7 @@ jobs:
           buildpack_artifact_prefix: ${{ inputs.buildpack_artifact_prefix }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v0.1.15
         with:
           tag_name: v${{ inputs.buildpack_version }}
           body_path: ${{ steps.artifacts.outputs.changes_file }}

--- a/.github/workflows/_buildpacks-release-update-builder.yml
+++ b/.github/workflows/_buildpacks-release-update-builder.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Create Pull Request
         id: pr
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v5.0.2
         with:
           token: ${{ steps.generate-token.outputs.app_token }}
           title: Update ${{ github.repository }} to v${{ inputs.buildpack_version }}

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Update Rust toolchain
         run: rustup update
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@v2.5.1
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- --deny warnings
       - name: rustfmt
@@ -38,7 +38,7 @@ jobs:
       - name: Update Rust toolchain
         run: rustup update
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@v2.5.1
       - name: Test
         run: cargo test --all-features
 
@@ -77,7 +77,7 @@ jobs:
       - name: Update Rust toolchain
         run: rustup update
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@v2.5.1
       - name: Build
         run: cargo build --release
       - name: Get Cargo Metadata
@@ -116,7 +116,7 @@ jobs:
 
           echo "path=${ASSET_PATH}" >> "$GITHUB_OUTPUT"
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v0.1.15
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
For security and determinism reasons.

Dependabot will then open PRs when they need updating, which we can carefully review before merging.

Fixes #73.
GUS-W-13795910.