### PR TITLE
Improve markdown and styling of generated changelog entries

### DIFF
--- a/src/commands/generate_changelog/command.rs
+++ b/src/commands/generate_changelog/command.rs
@@ -113,8 +113,8 @@ fn generate_changelog(changes_by_buildpack: &HashMap<BuildpackId, ChangelogEntry
         .collect::<BTreeMap<_, _>>()
         .into_iter()
         .filter_map(|(buildpack_id, changes)| match changes {
-            ChangelogEntry::Empty => Some(format!("# {buildpack_id}\n\n- No changes")),
-            ChangelogEntry::Changes(value) => Some(format!("# {buildpack_id}\n\n{value}")),
+            ChangelogEntry::Empty => Some(format!("## {buildpack_id}\n\n- No changes.")),
+            ChangelogEntry::Changes(value) => Some(format!("## {buildpack_id}\n\n{value}")),
             ChangelogEntry::VersionNotPresent => None,
         })
         .collect::<Vec<_>>()
@@ -145,18 +145,18 @@ mod test {
 
         assert_eq!(
             generate_changelog(&values),
-            r#"# a
+            r#"## a
 
 - change a.1
 - change a.2
 
-# c
+## c
 
 - change c.1
 
-# d
+## d
 
-- No changes
+- No changes.
 
 "#
         );

--- a/src/commands/prepare_release/command.rs
+++ b/src/commands/prepare_release/command.rs
@@ -329,7 +329,7 @@ fn promote_changelog_unreleased_to_version(
         Some(
             updated_dependencies
                 .iter()
-                .map(|id| format!("- Updated `{id}` to `{version}`"))
+                .map(|id| format!("- Updated `{id}` to `{version}`."))
                 .collect::<Vec<_>>()
                 .join("\n"),
         )
@@ -344,7 +344,7 @@ fn promote_changelog_unreleased_to_version(
     } else if let (None, Some(dependencies)) = changes_with_dependencies {
         dependencies.clone()
     } else {
-        "- No changes".to_string()
+        "- No changes.".to_string()
     };
 
     let new_release_entry = ReleaseEntry {
@@ -636,7 +636,7 @@ optional = true
             Some(&ReleaseEntry {
                 version: "0.8.17".parse::<Version>().unwrap(),
                 date,
-                body: "- No changes".to_string()
+                body: "- No changes.".to_string()
             })
         );
     }
@@ -700,7 +700,7 @@ optional = true
             Some(&ReleaseEntry {
                 version: "0.8.17".parse::<Version>().unwrap(),
                 date,
-                body: "- Added node version 18.15.0.\n- Added yarn version 4.0.0-rc.2\n- Updated `a` to `0.8.17`\n- Updated `b` to `0.8.17`".to_string()
+                body: "- Added node version 18.15.0.\n- Added yarn version 4.0.0-rc.2\n- Updated `a` to `0.8.17`.\n- Updated `b` to `0.8.17`.".to_string()
             })
         );
         assert_eq!(
@@ -743,7 +743,7 @@ optional = true
             Some(&ReleaseEntry {
                 version: "0.8.17".parse::<Version>().unwrap(),
                 date,
-                body: "- Updated `a` to `0.8.17`\n- Updated `b` to `0.8.17`".to_string()
+                body: "- Updated `a` to `0.8.17`.\n- Updated `b` to `0.8.17`.".to_string()
             })
         );
     }


### PR DESCRIPTION
- The buildpack name headings now use H2 headings rather than H1 (since there are multiple headings in the same document).
- All generated changelog entries (such as the ones for "No changes" or the ones describing a buildpack dependency version change) now end in a full stop.

Fixes #71.
Fixes #72.
GUS-W-13795916.