### PR TITLE
Downgrade request-add-entry action to v5.2.0

### DIFF
--- a/.github/workflows/_buildpacks-release-publish-cnb-registry.yml
+++ b/.github/workflows/_buildpacks-release-publish-cnb-registry.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Register the new version with the CNB Buildpack Registry
         if: steps.check.outputs.published_to_cnb_registry == 'false'
-        uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:5.3.0
+        uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:5.2.0
         with:
           token: ${{ secrets.cnb_registry_token }}
           id: ${{ inputs.buildpack_id }}


### PR DESCRIPTION
The image tag `5.3.0` cannot be found currently. Unsure if we updated without checking it actually exists or if the tag was removed after the fact. In any case, this PR downgrades to the latest version that is available on ghcr.io to unblock users of the actions.

Ref: https://github.com/heroku/languages-github-actions/pull/69