### PR TITLE
Adds a `dry_run` input to workflows for easier testing

### DIFF
--- a/.github/workflows/_buildpacks-prepare-release.yml
+++ b/.github/workflows/_buildpacks-prepare-release.yml
@@ -1,3 +1,5 @@
+name: _buildpacks-prepare-release
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/_buildpacks-release-detect.yml
+++ b/.github/workflows/_buildpacks-release-detect.yml
@@ -1,3 +1,5 @@
+name: _buildpacks-release-detect
+
 on:
   workflow_call:
     outputs:

--- a/.github/workflows/_buildpacks-release-package.yml
+++ b/.github/workflows/_buildpacks-release-package.yml
@@ -1,3 +1,5 @@
+name: _buildpacks-release-package
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/_buildpacks-release-publish-cnb-registry.yml
+++ b/.github/workflows/_buildpacks-release-publish-cnb-registry.yml
@@ -1,3 +1,5 @@
+name: _buildpacks-release-publish-cnb-registry
+
 on:
   workflow_call:
     inputs:
@@ -13,6 +15,11 @@ on:
         required: true
         type: string
         description: The docker repository to publish the buildpack to
+      dry_run:
+        required: false
+        type: boolean
+        default: false
+        description: Flag used for testing purposes that prevents the actual publish to the CNB registry
     secrets:
       cnb_registry_token:
         required: true
@@ -41,7 +48,7 @@ jobs:
         run: echo "value=$(crane digest ${{ inputs.docker_repository }}:${{ inputs.buildpack_version }})" >> "$GITHUB_OUTPUT"
 
       - name: Register the new version with the CNB Buildpack Registry
-        if: steps.check.outputs.published_to_cnb_registry == 'false'
+        if: inputs.dry_run == false && steps.check.outputs.published_to_cnb_registry == 'false'
         uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:5.2.0
         with:
           token: ${{ secrets.cnb_registry_token }}

--- a/.github/workflows/_buildpacks-release-publish-docker.yml
+++ b/.github/workflows/_buildpacks-release-publish-docker.yml
@@ -1,3 +1,5 @@
+name: _buildpacks-release-publish-docker
+
 on:
   workflow_call:
     inputs:
@@ -17,6 +19,11 @@ on:
         required: true
         type: string
         description: The docker repository to publish the buildpack to
+      dry_run:
+        required: false
+        type: boolean
+        default: false
+        description: Flag used for testing purposes that prevents the actual publish to docker
     secrets:
       docker_hub_user:
         required: true
@@ -43,6 +50,7 @@ jobs:
         run: zstd -dc --long=31 ${{ steps.artifacts.outputs.docker_image }} | docker load
 
       - name: Login to Docker Hub
+        if: inputs.dry_run == false
         uses: docker/login-action@v2.2.0
         with:
           registry: docker.io
@@ -52,9 +60,9 @@ jobs:
       - name: Check if version is already on Docker Hub
         id: check
         run: echo "published_to_docker=$(docker manifest inspect "${{ inputs.docker_repository }}:${{ inputs.buildpack_version }}" &> /dev/null && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
-      
+
       - name: Tag and publish buildpack
-        if: steps.check.outputs.published_to_docker == 'false'
+        if: inputs.dry_run == false && steps.check.outputs.published_to_docker == 'false'
         run: |
           docker tag ${{ inputs.buildpack_id }} ${{ inputs.docker_repository }}:${{ inputs.buildpack_version }}
           docker push ${{ inputs.docker_repository }}:${{ inputs.buildpack_version }}

--- a/.github/workflows/_buildpacks-release-publish-github.yml
+++ b/.github/workflows/_buildpacks-release-publish-github.yml
@@ -1,3 +1,5 @@
+name: _buildpacks-release-publish-github
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/_buildpacks-release-update-builder.yml
+++ b/.github/workflows/_buildpacks-release-update-builder.yml
@@ -1,3 +1,5 @@
+name: _buildpacks-release-update-builder
+
 on:
   workflow_call:
     inputs:
@@ -9,6 +11,11 @@ on:
         required: true
         type: string
         description: The version of the buildpacks that are being updated
+      dry_run:
+        required: false
+        type: boolean
+        default: false
+        description: Flag used for testing purposes that prevents actual changes to the heroku/builder repo
     secrets:
       app_private_key:
         description: Private key of GitHub application (Linguist)
@@ -45,6 +52,7 @@ jobs:
           version: ${{ inputs.buildpack_version }}
 
       - name: Update Builder
+        if: inputs.dry_run == false
         uses: heroku/languages-github-actions/.github/actions/update-builder@main
         with:
           repository_path: ./buildpacks


### PR DESCRIPTION
Also sets names for the workflow so they don't look like garbage in the [GitHub Actions UI for this repository](https://github.com/heroku/languages-github-actions/actions/)