### PR TITLE
Use [metadata.release.image] for repository key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,6 +299,7 @@ dependencies = [
  "regex",
  "semver",
  "serde_json",
+ "toml",
  "toml_edit",
  "uriparse",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,4 @@ toml_edit = "0.19"
 uriparse = "0.6"
 
 [dev-dependencies]
+toml = "0.7"

--- a/src/commands/generate_buildpack_matrix/command.rs
+++ b/src/commands/generate_buildpack_matrix/command.rs
@@ -1,4 +1,4 @@
-use crate::buildpacks::{find_releasable_buildpacks, read_docker_repository_metadata};
+use crate::buildpacks::{find_releasable_buildpacks, read_image_repository_metadata};
 use crate::commands::generate_buildpack_matrix::errors::Error;
 use crate::github::actions;
 use clap::Parser;
@@ -74,7 +74,7 @@ pub(crate) fn extract_buildpack_info(
 
     let buildpack_artifact_prefix = buildpack_id.replace('/', "_");
 
-    let docker_repository = read_docker_repository_metadata(&buildpack_data.buildpack_descriptor)
+    let docker_repository = read_image_repository_metadata(&buildpack_data.buildpack_descriptor)
         .ok_or(Error::MissingDockerRepositoryMetadata(buildpack_path))?;
 
     Ok(BTreeMap::from([

--- a/src/commands/update_builder/command.rs
+++ b/src/commands/update_builder/command.rs
@@ -1,5 +1,5 @@
 use crate::buildpacks::{
-    calculate_digest, find_releasable_buildpacks, read_docker_repository_metadata,
+    calculate_digest, find_releasable_buildpacks, read_image_repository_metadata,
 };
 use crate::update_builder::errors::Error;
 use clap::Parser;
@@ -65,7 +65,7 @@ pub(crate) fn execute(args: UpdateBuilderArgs) -> Result<()> {
             let buildpack_version = &buildpack_data.buildpack_descriptor.buildpack().version;
 
             let docker_repository =
-                read_docker_repository_metadata(&buildpack_data.buildpack_descriptor).ok_or(
+                read_image_repository_metadata(&buildpack_data.buildpack_descriptor).ok_or(
                     Error::MissingDockerRepositoryMetadata(buildpack_path.clone()),
                 )?;
 


### PR DESCRIPTION
This is a backwards-compatible fix to allow for our buildpacks to migrate away from `[metadata.release.docker]` to define our `repository` location in favor of the more agnostic `[metadata.release.image]`.

Fixes #45, [W-13738734](https://gus.lightning.force.com/a07EE00001Vrz9cYAB)