### PR TITLE
Use HashSet for list of changed buildpack ids

### DIFF
--- a/src/commands/prepare_release/command.rs
+++ b/src/commands/prepare_release/command.rs
@@ -326,11 +326,14 @@ fn promote_changelog_unreleased_to_version(
     let updated_dependencies_text = if updated_dependencies.is_empty() {
         None
     } else {
-        let mut updated_dependencies_bullet_points = updated_dependencies
-            .iter()
-            .map(|id| format!("- Updated `{id}` to `{version}`."))
-            .collect::<Vec<_>>();
-        updated_dependencies_bullet_points.sort();
+        let updated_dependencies_bullet_points = {
+            let mut updated_dependencies_bullet_points = updated_dependencies
+                .iter()
+                .map(|id| format!("- Updated `{id}` to `{version}`."))
+                .collect::<Vec<_>>();
+            updated_dependencies_bullet_points.sort();
+            updated_dependencies_bullet_points
+        };
         Some(updated_dependencies_bullet_points.join("\n"))
     };
 

--- a/src/commands/prepare_release/command.rs
+++ b/src/commands/prepare_release/command.rs
@@ -326,14 +326,11 @@ fn promote_changelog_unreleased_to_version(
     let updated_dependencies_text = if updated_dependencies.is_empty() {
         None
     } else {
-        let updated_dependencies_bullet_points = {
-            let mut updated_dependencies_bullet_points = updated_dependencies
-                .iter()
-                .map(|id| format!("- Updated `{id}` to `{version}`."))
-                .collect::<Vec<_>>();
-            updated_dependencies_bullet_points.sort();
-            updated_dependencies_bullet_points
-        };
+        let mut updated_dependencies_bullet_points = updated_dependencies
+            .iter()
+            .map(|id| format!("- Updated `{id}` to `{version}`."))
+            .collect::<Vec<_>>();
+        updated_dependencies_bullet_points.sort();
         Some(updated_dependencies_bullet_points.join("\n"))
     };
 


### PR DESCRIPTION
Meta-buildpacks can have multiple order group that list the same buildpack ids.  This PR switches the list of buildpack ids that have been updated from a `Vec<BuildpackId>` to a `HashSet<BuildpackId>` to prevent duplicate entries from ending up in changelogs.

Fixes #70, [W-13792776](https://gus.lightning.force.com/a07EE00001WZQhJYAX)