### PR TITLE
Post PR #88 Cleanup

### DIFF
--- a/src/buildpacks.rs
+++ b/src/buildpacks.rs
@@ -37,14 +37,7 @@ pub(crate) fn read_image_repository_metadata(
     metadata
         .as_ref()
         .and_then(|metadata| metadata.get("release").and_then(|value| value.as_table()))
-        .and_then(|release| {
-            release
-                .get("image")
-                // TODO: remove this once each buildpack.toml metadata is updated to
-                //       replace [metadata.release.docker] with [metadata.release.image]
-                .or_else(|| release.get("docker"))
-                .and_then(|value| value.as_table())
-        })
+        .and_then(|release| release.get("image").and_then(|value| value.as_table()))
         .and_then(|docker| docker.get("repository").and_then(|value| value.as_str()))
         .map(|value| value.to_string())
 }
@@ -63,30 +56,6 @@ mod test {
     use crate::buildpacks::read_image_repository_metadata;
     use libcnb_data::buildpack::BuildpackDescriptor;
     use libcnb_package::GenericMetadata;
-
-    #[test]
-    fn test_read_image_repository_metadata_deprecated() {
-        let data = r#"
-api = "0.9"
-
-[buildpack]
-id = "foo/bar"
-version = "0.0.1"
-
-[[stacks]]
-id = "*"
-
-[metadata.release.docker]
-repository = "deprecated repository value"
-"#;
-
-        let buildpack_descriptor =
-            toml::from_str::<BuildpackDescriptor<GenericMetadata>>(data).unwrap();
-        assert_eq!(
-            read_image_repository_metadata(&buildpack_descriptor),
-            Some("deprecated repository value".to_string())
-        );
-    }
 
     #[test]
     fn test_read_image_repository_metadata() {


### PR DESCRIPTION
We can remove this fallback key for reading the repository to publish to now that the following PRs have been merged:

- https://github.com/heroku/buildpacks-go/pull/124
- https://github.com/heroku/buildpacks-php/pull/15
- https://github.com/heroku/buildpacks-ruby/pull/184
- https://github.com/heroku/buildpacks-jvm/pull/555
- https://github.com/heroku/buildpacks-nodejs/pull/610
- https://github.com/heroku/buildpacks-python/pull/58
- https://github.com/heroku/procfile-cnb/pull/156