### PR TITLE
Use a consistent branch name when opening PRs

### DIFF
--- a/.github/workflows/_buildpacks-prepare-release.yml
+++ b/.github/workflows/_buildpacks-prepare-release.yml
@@ -79,7 +79,8 @@ jobs:
           token: ${{ steps.generate-token.outputs.app_token }}
           title: Prepare release v${{ steps.prepare.outputs.to_version }}
           commit-message: Prepare release v${{ steps.prepare.outputs.to_version }}
-          branch: prepare/v${{ steps.prepare.outputs.to_version }}
+          branch: prepare-release
+          delete-branch: true
           body: ${{ steps.generate-changelog.outputs.changelog }}
           labels: "automation"
 

--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -255,7 +255,8 @@ jobs:
           title: Update ${{ github.repository }} to v${{ needs.compile.outputs.version }}
           commit-message: Update ${{ github.repository }} to v${{ needs.compile.outputs.version }}
           path: ./builder
-          branch: update/${{ github.repository }}/${{ needs.compile.outputs.version }}
+          branch: update/${{ github.repository }}
+          delete-branch: true
           body: ${{ needs.compile.outputs.changelog }}
 
       - name: Configure PR


### PR DESCRIPTION
Previously the automation included the buildpack release version in the branch name used for both the "Prepare release" and "Update builder" PRs.

For example:
`prepare/v0.1.7`
`update/heroku/buildpacks-go/0.1.7`

This meant that multiple PRs can end up being opened, for example if:
- Someone triggers a "Prepare release" PR, but then triggers another with a different bump level (such as if they realised they had chosen the wrong version bump initiall)
- The "Update builder" PR is not merged for one release, before the next release occurs (as seen in ).

Now, the branch names no longer include the buildpack version, for example:
`prepare-release`
`update/heroku/buildpacks-go`

...meaning that the initial PR gets updated instead, per:
https://github.com/peter-evans/create-pull-request#action-behaviour

GUS-W-13907279.