### PR TITLE
Don't add the `automation` label to prepare release PRs

### DIFF
--- a/.github/workflows/_buildpacks-prepare-release.yml
+++ b/.github/workflows/_buildpacks-prepare-release.yml
@@ -82,7 +82,6 @@ jobs:
           branch: prepare-release
           delete-branch: true
           body: ${{ steps.generate-changelog.outputs.changelog }}
-          labels: "automation"
 
       - name: Configure pull request
         if: steps.pr.outputs.pull-request-operation == 'created'


### PR DESCRIPTION
Since:
- The PR is opened by a bot account, so it's already clear that it's not been triggered by a human.
- The `create-pull-request` action doesn't add the label at time of PR creation and instead [adds it shortly after](https://github.com/peter-evans/create-pull-request/blob/3f6dd507d6db1a5a5de747205453b550f1da8dbc/src/github-helper.ts#L137-L145), which causes an unnecessary second triggering of any CI checks that listen to the `labelled` event (such as the Check Changelog Action).

Example duplicate Check Changelog run:

<img width="795" alt="Duplicate check changelog run" src="https://github.com/heroku/languages-github-actions/assets/501702/20d53987-0f9f-409e-83dd-cd0ee0a36ad3">
