### PR TITLE
Include the release changelog in the commit message too

### DIFF
--- a/.github/workflows/_buildpacks-prepare-release.yml
+++ b/.github/workflows/_buildpacks-prepare-release.yml
@@ -78,10 +78,13 @@ jobs:
         with:
           token: ${{ steps.generate-token.outputs.app_token }}
           title: Prepare release v${{ steps.prepare.outputs.to_version }}
-          commit-message: Prepare release v${{ steps.prepare.outputs.to_version }}
+          body: ${{ steps.generate-changelog.outputs.changelog }}
+          commit-message: |
+            Prepare release v${{ steps.prepare.outputs.to_version }}
+
+            ${{ steps.generate-changelog.outputs.changelog }}
           branch: prepare-release
           delete-branch: true
-          body: ${{ steps.generate-changelog.outputs.changelog }}
 
       - name: Configure pull request
         if: steps.pr.outputs.pull-request-operation == 'created'

--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -253,11 +253,14 @@ jobs:
         with:
           token: ${{ steps.generate-token.outputs.app_token }}
           title: Update ${{ github.repository }} to v${{ needs.compile.outputs.version }}
-          commit-message: Update ${{ github.repository }} to v${{ needs.compile.outputs.version }}
+          body: ${{ needs.compile.outputs.changelog }}
+          commit-message: |
+            Update ${{ github.repository }} to v${{ needs.compile.outputs.version }}
+
+            ${{ needs.compile.outputs.changelog }}
           path: ./builder
           branch: update/${{ github.repository }}
           delete-branch: true
-          body: ${{ needs.compile.outputs.changelog }}
 
       - name: Configure PR
         if: steps.pr.outputs.pull-request-operation == 'created'


### PR DESCRIPTION
Previously the changelog for a CNB release was only included in the PR descriptions, and not the commit message. 

Now the changelog is included in the commit message too, which means it's possible to understand what changed when looking at the commit view, without needing to open up the PR to read there instead.

GUS-W-13912483.