### PR TITLE
Fix GitHub publish

### DIFF
--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -166,10 +166,7 @@ jobs:
         id: check
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.app_token }}
-        run: echo "published_to_github=$(gh release view v0.0.3 &> /dev/null && echo "true" || echo "false")" >> $GITHUB_OUTPUT
-
-      - name: Test
-        run: echo "${{ steps.check.outputs.published_to_github }}"
+        run: echo "published_to_github=$(gh release view v${{ needs.compile.outputs.version }} &> /dev/null && echo "true" || echo "false")" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
         if: steps.check.outputs.published_to_github == 'false'

--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -149,10 +149,10 @@ jobs:
 
       - name: Generate CNB files
         run: |
-          for buildpack in $(echo '${{ needs.compile.outputs.buildpacks }}' | jq -c '.[]'); do
-            artifact_prefix=$(echo "${buildpack}" | jq -r '.buildpack_artifact_prefix')
-            output_dir=$(echo "${buildpack}" | jq -r '.buildpack_output_dir')
-            pack buildpack package ${artifact_prefix}.cnb --config ${output_dir}/package.toml --format file -v
+          for buildpack in $(jq -c '.[]' <<< '${{ needs.compile.outputs.buildpacks }}'); do
+            artifact_prefix=$(jq -r '.buildpack_artifact_prefix' <<< "${buildpack}")
+            output_dir=$(jq -r '.buildpack_output_dir' <<< "${buildpack}")
+            pack buildpack package "${artifact_prefix}.cnb" --config "${output_dir}/package.toml" --format file --verbose
           done
 
       - name: Get token for GitHub application (Linguist)

--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -168,6 +168,9 @@ jobs:
           GH_TOKEN: ${{ steps.generate-token.outputs.app_token }}
         run: echo "published_to_github=$(gh release view v0.0.3 &> /dev/null && echo "true" || echo "false")" >> $GITHUB_OUTPUT
 
+      - name: Test
+        run: echo "${{ steps.check.outputs.published_to_github }}"
+
       - name: Create GitHub Release
         if: steps.check.outputs.published_to_github == 'false'
         uses: softprops/action-gh-release@v0.1.15

--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -166,7 +166,7 @@ jobs:
         id: check
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.app_token }}
-        run: echo "published_to_github=$(gh release view v${{ needs.compile.outputs.version }} &> /dev/null && echo "true" || echo "false")" >> $GITHUB_OUTPUT
+        run: echo "published_to_github=$(gh release view v${{ needs.compile.outputs.version }} -R ${{ github.repository }} &> /dev/null && echo "true" || echo "false")" >> $GITHUB_OUTPUT
 
       - name: Test
         run: echo "${{ steps.check.outputs.published_to_github }}"

--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -147,7 +147,7 @@ jobs:
       - name: Install Pack CLI
         uses: buildpacks/github-actions/setup-pack@v5.3.1
 
-      - name: Save CNB Files
+      - name: Generate CNB files
         run: |
           for buildpack in $(echo '${{ needs.compile.outputs.buildpacks }}' | jq -c '.[]'); do
             artifact_prefix=$(echo "${buildpack}" | jq -r '.buildpack_artifact_prefix')

--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -169,7 +169,7 @@ jobs:
         run: echo "published_to_github=$(gh release view v${{ needs.compile.outputs.version }} -R ${{ github.repository }} &> /dev/null && echo "true" || echo "false")" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
-        if: steps.check.outputs.published_to_github == 'false'
+        if: inputs.dry_run == false && steps.check.outputs.published_to_github == 'false'
         uses: softprops/action-gh-release@v0.1.15
         with:
           token: ${{ steps.generate-token.outputs.app_token }}

--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -168,11 +168,8 @@ jobs:
           GH_TOKEN: ${{ steps.generate-token.outputs.app_token }}
         run: echo "published_to_github=$(gh release view v${{ needs.compile.outputs.version }} -R ${{ github.repository }} &> /dev/null && echo "true" || echo "false")" >> $GITHUB_OUTPUT
 
-      - name: Test
-        run: echo "${{ steps.check.outputs.published_to_github }}"
-
       - name: Create GitHub Release
-        if: steps.check.outputs.published_to_github == 'false'
+        if: inputs.dry_run == false && steps.check.outputs.published_to_github == 'false'
         uses: softprops/action-gh-release@v0.1.15
         with:
           token: ${{ steps.generate-token.outputs.app_token }}

--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -134,10 +134,6 @@ jobs:
     name: Publish → GitHub - ${{ matrix.buildpack_id }}
     needs: [compile]
     runs-on: ${{ inputs.ip_allowlisted_runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJSON(needs.compile.outputs.buildpacks) }}
     steps:
       - name: Restore buildpacks
         uses: actions/cache/restore@v3
@@ -151,8 +147,13 @@ jobs:
       - name: Install Pack CLI
         uses: buildpacks/github-actions/setup-pack@v5.3.1
 
-      - name: Save CNB File
-        run: pack buildpack package ${{ matrix.buildpack_artifact_prefix }}.cnb --config ${{ matrix.buildpack_output_dir }}/package.toml --format file -v
+      - name: Save CNB Files
+        run: |
+          for buildpack in $(echo '${{ needs.compile.outputs.buildpacks }}' | jq -c '.[]'); do
+            artifact_prefix=$(echo "${buildpack}" | jq -r '.buildpack_artifact_prefix')
+            output_dir=$(echo "${buildpack}" | jq -r '.buildpack_output_dir')
+            pack buildpack package ${artifact_prefix}.cnb --config ${output_dir}/package.toml --format file -v
+          done
 
       - name: Get token for GitHub application (Linguist)
         uses: heroku/use-app-token-action@main
@@ -167,7 +168,7 @@ jobs:
           token: ${{ steps.generate-token.outputs.app_token }}
           tag_name: v${{ matrix.buildpack_version }}
           body: ${{ needs.compile.outputs.changelog }}
-          files: ${{ matrix.buildpack_artifact_prefix }}.cnb
+          files: "*.cnb"
           fail_on_unmatched_files: true
 
   publish-cnb:

--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -166,7 +166,7 @@ jobs:
         uses: softprops/action-gh-release@v0.1.15
         with:
           token: ${{ steps.generate-token.outputs.app_token }}
-          tag_name: v${{ matrix.buildpack_version }}
+          tag_name: v${{ needs.compile.outputs.version }}
           body: ${{ needs.compile.outputs.changelog }}
           files: "*.cnb"
           fail_on_unmatched_files: true

--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -168,6 +168,9 @@ jobs:
           GH_TOKEN: ${{ steps.generate-token.outputs.app_token }}
         run: echo "published_to_github=$(gh release view v${{ needs.compile.outputs.version }} &> /dev/null && echo "true" || echo "false")" >> $GITHUB_OUTPUT
 
+      - name: Test
+        run: echo "${{ steps.check.outputs.published_to_github }}"
+
       - name: Create GitHub Release
         if: steps.check.outputs.published_to_github == 'false'
         uses: softprops/action-gh-release@v0.1.15

--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -169,7 +169,7 @@ jobs:
         run: echo "published_to_github=$(gh release view v0.0.3 &> /dev/null && echo "true" || echo "false")" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
-        if: inputs.dry_run == false && steps.check.outputs.published_to_github == 'false'
+        if: steps.check.outputs.published_to_github == 'false'
         uses: softprops/action-gh-release@v0.1.15
         with:
           token: ${{ steps.generate-token.outputs.app_token }}

--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -169,7 +169,7 @@ jobs:
         run: echo "published_to_github=$(gh release view v${{ needs.compile.outputs.version }} -R ${{ github.repository }} &> /dev/null && echo "true" || echo "false")" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
-        if: inputs.dry_run == false && steps.check.outputs.published_to_github == 'false'
+        if: steps.check.outputs.published_to_github == 'false'
         uses: softprops/action-gh-release@v0.1.15
         with:
           token: ${{ steps.generate-token.outputs.app_token }}

--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -131,7 +131,7 @@ jobs:
           docker push ${{ matrix.docker_repository }}:${{ matrix.buildpack_version }}
 
   publish-github:
-    name: Publish → GitHub - ${{ matrix.buildpack_id }}
+    name: Publish → GitHub Release
     needs: [compile]
     runs-on: ${{ inputs.ip_allowlisted_runner }}
     steps:
@@ -162,7 +162,14 @@ jobs:
           app_id: ${{ inputs.app_id }}
           private_key: ${{ secrets.app_private_key }}
 
+      - name: Check if release exists
+        id: check
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.app_token }}
+        run: echo "published_to_github=$(gh release view v0.0.3 &> /dev/null && echo "true" || echo "false")" >> $GITHUB_OUTPUT
+
       - name: Create GitHub Release
+        if: inputs.dry_run == false && steps.check.outputs.published_to_github == 'false'
         uses: softprops/action-gh-release@v0.1.15
         with:
           token: ${{ steps.generate-token.outputs.app_token }}


### PR DESCRIPTION
Changes the GitHub release process from being performed using a strategy for each buildpack which would perform partial overwrites of the release details and assets to packaging all the `*.cnb` files using a bash loop + `jq` and creating a single release with all the assets attached.

With this modification, a guard check can now be added to check if the release exists before attempting to create the release.  The "Create GitHub Release" step will be skipped if the release already exists or we're running the actions in `dry_run=true` mode. This should prevent a GH release from being clobbered if the release workflow is accidentally triggered without running the prepare release workflow first.

Fixes #89, [W-13871126](https://gus.lightning.force.com/a07EE00001XRghXYAT)