### PR TITLE
Temporary fix to handle bash-buildpacks

### DIFF
--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -90,6 +90,44 @@ jobs:
         id: generate-changelog
         run: actions generate-changelog --version ${{ steps.generate-buildpack-matrix.outputs.version }}
 
+      - name: Temporary fix for bash-based buildpacks
+        run: |
+          buildpacks='${{ steps.generate-buildpack-matrix.outputs.buildpacks }}'
+
+          bash_buildpack_source_dirs=()
+          bash_buildpack_output_dirs=()
+
+          # copy any bash-based buildpack to target buildpack dir because `cargo libcnb package` will ignore them
+          for buildpack in $(jq -c '.[]' <<< "${buildpacks}"); do
+            buildpack_dir=$(jq -r '.buildpack_dir' <<< "${buildpack}")
+            output_dir=$(jq -r '.buildpack_output_dir' <<< "${buildpack}")
+            if [ ! -d "${output_dir}" ]; then
+              echo "bash-based buildpack detected at ${buildpack_dir}"
+              cp -R "${buildpack_dir}" "${output_dir}"
+              bash_buildpack_source_dirs+=("${buildpack_dir}")
+              bash_buildpack_output_dirs+=("${output_dir}")
+            fi
+          done
+
+          # replace dependencies that reference a bash-buildpack
+          for buildpack in $(jq -c '.[]' <<< "${buildpacks}"); do
+            output_dir=$(jq -r '.buildpack_output_dir' <<< "${buildpack}")
+            echo "checking dependencies in ${output_dir}/package.toml"
+            for dep in $(yq -oy '.dependencies[].uri' "${output_dir}/package.toml"); do
+              if realpath "${dep}" &> /dev/null; then
+                dep_path=$(realpath "${dep}")
+                for i in "${!bash_buildpack_source_dirs[@]}"; do
+                  bash_buildpack_source_dir="${bash_buildpack_source_dirs[$i]}"
+                  bash_buildpack_output_dir="${bash_buildpack_output_dirs[$i]}"
+                  if [ "${bash_buildpack_source_dir}" = "${dep_path}" ]; then
+                    echo "replacing ${dep} with ${bash_buildpack_output_dir}"
+                    sed -i 's|'"$dep"'|'"$bash_buildpack_output_dir"'|g' "${output_dir}/package.toml"
+                  fi
+                done
+              fi
+            done
+          done
+
       - name: Cache buildpacks
         uses: actions/cache/save@v3
         with:


### PR DESCRIPTION
> This is not ideal but should work until we get convert our bash-based CNBs into libcnb-based ones (i.e.; [heroku/nodejs-npm](https://github.com/heroku/buildpacks-nodejs/tree/main/buildpacks/npm)).

Bash-based CNB must be handled as special cases in our release workflow. Prior to #91 we were compiling buildpacks individually using a strategy job.  This worked well for a bash-based CNB since the output directory was obtained from the output of running `cargo libcnb package` in the CNB source directory which reports the correct output location for bash- and libcnb-based CNBs.  Then our compiled image and `.cnb` files were created using that output directory.

After #91, the process was restructured to perform the compilation of all the buildpacks at once by running `cargo libcnb package` in the project root and pre-populating the output directories in the `generate-buildpack-matrix` step. Because `cargo libcnb package` leaves bash-based CNBs alone, no directory in `target/buildpack/...` is created so the pre-populated output directory is incorrect.  Furthermore, we only cache the `target/buildpack` directory for later use to create our compiled image and `.cnb` files so effectively any bash-based CNB is missing from the overall process.

This PR introduces a temporary workaround to run a step during the compilation job that:
- moves any bash-based CNB to the intended `target/buildpack` directory that is given by `generate-buildpack-matrix`
- each `target/buildpack/**/package.toml` file is then scanned to see if it contains a reference to a bash-based CNB
  - if so, that dependency is replaced with the location of the bash-based CNB in the `target/buildpack` folder 

This has been tested using [colincasey/noop-cnb](https://github.com/colincasey/noop-cnb) which is configured with a project structure to reproduce this issue:
- [here](https://github.com/colincasey/noop-cnb/actions/runs/5824266340) is a run using the shared workflow with `@latest` which, as expected, fails
- [here](https://github.com/colincasey/noop-cnb/actions/runs/5824294612) is a run using the shared workflow with `@fix_bash_buildpacks` which handles this bash-based CNB edge case and succeeds