### PR TITLE
Pin the `libcnb-cargo` version to the same version as `libcnb-package`

### DIFF
--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -71,7 +71,9 @@ jobs:
         uses: Swatinem/rust-cache@v2.6.0
 
       - name: Install libcnb-cargo
-        run: cargo install libcnb-cargo
+        # TODO: Derive this version from the `libcnb-package` version in this repo's `Cargo.toml`,
+        # or at least add a CI check to ensure the two versions are in sync.
+        run: cargo install --locked libcnb-cargo@0.13.0
 
       - name: Install Languages CLI
         uses: heroku/languages-github-actions/.github/actions/install-languages-cli@main

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,9 @@ clap = { version = "4", default-features = false, features = [
 ] }
 indexmap = "2"
 lazy_static = "1"
-libcnb-data = "0.13"
-libcnb-package = "0.13"
+# NB: Make sure to keep the `libcnb-cargo` version in `_buildpacks-release.yml` in sync with these.
+libcnb-data = "=0.13.0"
+libcnb-package = "=0.13.0"
 markdown = "1.0.0-alpha.12"
 rand = "0.8"
 regex = "1"


### PR DESCRIPTION
The workflows in this repo use libcnb in two ways:
1. As a library (specifically `libcnb-package` and `libcnb-data`)
2. As a binary (`cargo libcnb package`)

The version of (1) is controlled by `Cargo.toml` / `Cargo.lock` in this repo.

Previously the version of (2) wasn't pinned at all, and instead the latest version would be used, meaning that version could get out of sync with that of (1).

Now, the version is manually pinned to the same version as in `Cargo.toml`.

Longer term this should either be replaced by deriving the version in the workflow, or at least having a CI check/lint that ensures the two are in sync.

However, for the short term we want to just fix CNB releases after the 0.14.0 libcnb release, until we have time to make the necessary changes in #120.