### PR TITLE
Fix missing trailing newline in generated CHANGELOG.md

### DIFF
--- a/src/commands/prepare_release/command.rs
+++ b/src/commands/prepare_release/command.rs
@@ -118,7 +118,8 @@ pub(crate) fn execute(args: PrepareReleaseArgs) -> Result<()> {
             repository_url.to_string(),
             &declarations_starting_version,
         );
-        let changelog_contents = format!("{new_changelog}\n{release_declarations}");
+
+        let changelog_contents = format!("{new_changelog}\n{release_declarations}\n");
 
         write(&changelog_file.path, changelog_contents)
             .map_err(|e| Error::WritingChangelog(changelog_file.path.clone(), e))?;


### PR DESCRIPTION
Unfortunately with the current design of `prepare-release` it's not easy to test this, so I was not able to add a test.

Fixes #127.
GUS-W-13981097.