### PR TITLE
Fix bot commit signing

### DIFF
--- a/.github/workflows/_buildpacks-prepare-release.yml
+++ b/.github/workflows/_buildpacks-prepare-release.yml
@@ -59,12 +59,6 @@ jobs:
           # that can be used to make signed commits that are attributed to the GH application user
           token: ${{ steps.generate-token.outputs.app_token }}
 
-      # This will ensure commits made from this workflow are attributed to the GH application user
-      - name: Configure git
-        run: |
-          git config --global user.name ${{ inputs.app_username }}
-          git config --global user.email ${{ inputs.app_email }}
-
       - name: Install Languages CLI
         uses: heroku/languages-github-actions/.github/actions/install-languages-cli@main
 
@@ -93,6 +87,9 @@ jobs:
             ${{ steps.generate-changelog.outputs.changelog }}
           branch: prepare-release
           delete-branch: true
+          # This will ensure commits made from this workflow are attributed to the GH application user
+          committer: ${{ inputs.app_username }} <${{ inputs.app_email }}>
+          author: ${{ inputs.app_username }} <${{ inputs.app_email }}>
 
       - name: Configure pull request
         if: steps.pr.outputs.pull-request-operation == 'created'

--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -284,12 +284,6 @@ jobs:
           # that can be used to make signed commits that are attributed to the GH application user
           token: ${{ steps.generate-token.outputs.app_token }}
 
-      # This will ensure commits made from this workflow are attributed to the GH application user
-      - name: Configure git
-        run: |
-          git config --global user.name ${{ inputs.app_username }}
-          git config --global user.email ${{ inputs.app_email }}
-
       - name: Install crane
         uses: buildpacks/github-actions/setup-tools@v5.4.0
 
@@ -317,6 +311,9 @@ jobs:
           path: ./builder
           branch: update/${{ github.repository }}
           delete-branch: true
+          # This will ensure commits made from this workflow are attributed to the GH application user
+          committer: ${{ inputs.app_username }} <${{ inputs.app_email }}>
+          author: ${{ inputs.app_username }} <${{ inputs.app_email }}>
 
       - name: Configure PR
         if: steps.pr.outputs.pull-request-operation == 'created'


### PR DESCRIPTION
The previous configuration worked if commits were done manually with a `git commit ...` but the [peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request) action will use the GitHub Actions bot as committer and the user that triggered the workflow as author if  `committer` and `author` are not given as inputs.

Fixes #132 
GUS-W-14041925.