### PR TITLE
Allow testing of CLI changes from a branch

### DIFF
--- a/.github/actions/install-languages-cli/action.yml
+++ b/.github/actions/install-languages-cli/action.yml
@@ -2,6 +2,10 @@ name: Install Languages CLI
 description: Downloads the Languages CLI from a known release or installs using Cargo
 
 inputs:
+  branch:
+    required: false
+    description: The branch to install the CLI from (only used when `download_url` is not provided)
+    default: main
   download_url:
     required: false
     description: The url to download the CLI binary from
@@ -22,7 +26,7 @@ runs:
     - name: Build actions binary
       shell: bash
       if: inputs.download_url == ''
-      run: cargo install --locked --git https://github.com/heroku/languages-github-actions.git
+      run: cargo install --locked --git https://github.com/heroku/languages-github-actions.git --branch ${{ inputs.branch }}
 
     - name: Download actions binary
       shell: bash

--- a/.github/actions/install-languages-cli/action.yml
+++ b/.github/actions/install-languages-cli/action.yml
@@ -3,6 +3,10 @@ description: Downloads the Languages CLI from a known release or installs using 
 
 inputs:
   branch:
+    # This input is currently the only way we can modify which branch to install the CLI tooling from. Ideally we
+    # would be able to use [`job_workflow_sha`](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context)
+    # and always install from the same branch as the workflow but, due to a [bug](https://github.com/actions/runner/issues/2417)
+    # in the GitHub Action runner, the value is never populated :(
     required: false
     description: The branch to install the CLI from (only used when `download_url` is not provided)
     default: main

--- a/.github/workflows/_buildpacks-prepare-release.yml
+++ b/.github/workflows/_buildpacks-prepare-release.yml
@@ -35,6 +35,11 @@ on:
         type: string
         required: false
         default: pub-hk-ubuntu-22.04-small
+      languages_cli_branch:
+        description: The branch to install the Languages CLI from (FOR TESTING)
+        type: string
+        required: false
+        default: main
     secrets:
       app_private_key:
         description: Private key of GitHub application (Linguist)
@@ -67,6 +72,8 @@ jobs:
 
       - name: Install Languages CLI
         uses: heroku/languages-github-actions/.github/actions/install-languages-cli@main
+        with:
+          branch: ${{ inputs.languages_cli_branch }}
 
       - name: Bump versions and update changelogs
         id: prepare

--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -30,6 +30,11 @@ on:
         type: string
         required: false
         default: pub-hk-ubuntu-22.04-small
+      languages_cli_branch:
+        description: The branch to install the Languages CLI from (FOR TESTING)
+        type: string
+        required: false
+        default: main
     secrets:
       app_private_key:
         description: Private key of GitHub application (e.g. the Linguist App)
@@ -78,6 +83,7 @@ jobs:
       - name: Install Languages CLI
         uses: heroku/languages-github-actions/.github/actions/install-languages-cli@main
         with:
+          branch: ${{ inputs.languages_cli_branch }}
           update_rust_toolchain: false
 
       - name: Package buildpacks
@@ -295,6 +301,8 @@ jobs:
 
       - name: Install Languages CLI
         uses: heroku/languages-github-actions/.github/actions/install-languages-cli@main
+        with:
+          branch: ${{ inputs.languages_cli_branch }}
 
       - name: Update Builder
         # The dry run check is performed here because the update process requires a published

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Before using the shared workflows below, please be sure to configure the followi
   to **Allow auto-merge**.
 
 > If either of these settings are misconfigured you will encounter errors during steps that
-> create or configure pull requests. For example, an error message of **"Pull request User is 
+> create or configure pull requests. For example, an error message of **"Pull request User is
 > not authorized for this protected branch"** indicates the branch protection rules are missing
 > the GitHub Application bot user.
 
@@ -77,6 +77,7 @@ jobs:
 | `bump`                          | Which component of the version to increment (major, minor, or patch)                                                                                                                                    | true     |                             |
 | `declarations_starting_version` | Only needed if existing releases have been published but there is no matching release tag in Git. If this is the case, the first git tag that matches a version from your CHANGELOG should be supplied. | false    |                             |
 | `ip_allowlisted_runner`         | The GitHub Actions runner to use to run jobs that require IP allow-list privileges                                                                                                                      | false    | `pub-hk-ubuntu-22.04-small` |
+| `languages_cli_branch`          | The branch to install the Languages CLI from (FOR TESTING)                                                                                                                                              | false    | `main`                      |
 
 #### Secrets
 
@@ -136,6 +137,7 @@ jobs:
 | `app_id`                | Application ID of GitHub application (e.g. the Linguist App)                                        | true     |                             |
 | `dry_run`               | Flag used for testing purposes to prevent actions that perform publishing operations from executing | false    | false                       |
 | `ip_allowlisted_runner` | The GitHub Actions runner to use to run jobs that require IP allow-list privileges                  | false    | `pub-hk-ubuntu-22.04-small` |
+| `languages_cli_branch`  | The branch to install the Languages CLI from (FOR TESTING)                                          | false    | `main`                      |
 
 #### Secrets
 


### PR DESCRIPTION
This PR exposes inputs on the release workflow (`languages_cli_branch`) that allow a `branch` to be passed through to the `install-languages-cli` action.

For automations that invoke these reusable workflows, this will allow CLI changes to be tested from a feature branch before they are merged into `main`.

Fixes #106 
GUS-W-13955891.