### PR TITLE
Group minor/patch version Rust Dependabot updates into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,12 @@ updates:
     schedule:
       interval: "monthly"
     groups:
+      # Note: The group order matters, since updates are assigned to the first matching group.
       libcnb:
         patterns:
           - "libcnb*"
           - "libherokubuildpack"
+      rust-dependencies:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Previously only libcnb related dependency updates were grouped into one Dependabot PR.

Now there is a second group, that takes advantage of Dependabot's new semver version level grouping feature:
https://github.blog/changelog/2023-08-17-grouped-version-updates-by-semantic-version-level-for-dependabot/

GUS-W-13990911.