### PR TITLE
Upgrade `libcnb.rs` to `0.15.0`

### DIFF
--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -2,6 +2,7 @@ name: _buildpacks-release
 
 env:
   CARGO_TERM_COLOR: always
+  PACKAGE_DIR: ./packaged
 
 on:
   workflow_call:
@@ -98,7 +99,7 @@ jobs:
 
       - name: Generate buildpack matrix
         id: generate-buildpack-matrix
-        run: actions generate-buildpack-matrix
+        run: actions generate-buildpack-matrix --package-directory ${{ env.PACKAGE_DIR }}
 
       - name: Generate changelog
         id: generate-changelog
@@ -146,7 +147,7 @@ jobs:
         uses: actions/cache/save@v3
         with:
           key: ${{ github.run_id }}-compiled-buildpacks
-          path: target/buildpack
+          path: ${{ env.PACKAGE_DIR }}
 
   publish-docker:
     name: Publish → Docker - ${{ matrix.buildpack_id }}
@@ -162,7 +163,7 @@ jobs:
         with:
           fail-on-cache-miss: true
           key: ${{ github.run_id }}-compiled-buildpacks
-          path: target/buildpack
+          path: ${{ env.PACKAGE_DIR }}
         env:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
 
@@ -200,7 +201,7 @@ jobs:
         with:
           fail-on-cache-miss: true
           key: ${{ github.run_id }}-compiled-buildpacks
-          path: target/buildpack
+          path: ${{ env.PACKAGE_DIR }}
         env:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+
+[[package]]
+name = "bstr"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.15.4"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
+checksum = "fb9ac64500cc83ce4b9f8dafa78186aa008c8dea77a09b94cd307fd0cd5022a8"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -176,6 +192,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "errno"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "fancy-regex"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,10 +246,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.12.3"
+name = "globset"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+checksum = "759c97c1e17c55525b57192c06a267cda0ac5210b222d6b82189a2338fa1c13d"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
 
 [[package]]
 name = "hashbrown"
@@ -225,6 +269,15 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "home"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -250,13 +303,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "1.9.3"
+name = "ignore"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+checksum = "dbe7873dab538a9a44ad79ede1faf5f30d49f9a5c883ddbab48bce81b64b7492"
 dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
+ "globset",
+ "lazy_static",
+ "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -266,7 +326,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.0",
+ "hashbrown",
 ]
 
 [[package]]
@@ -290,8 +350,10 @@ version = "0.0.1"
 dependencies = [
  "chrono",
  "clap",
- "indexmap 2.0.0",
+ "ignore",
+ "indexmap",
  "lazy_static",
+ "libcnb-common",
  "libcnb-data",
  "libcnb-package",
  "markdown",
@@ -299,8 +361,8 @@ dependencies = [
  "regex",
  "semver",
  "serde_json",
- "toml",
- "toml_edit",
+ "toml 0.7.6",
+ "toml_edit 0.19.14",
  "uriparse",
 ]
 
@@ -312,48 +374,68 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+
+[[package]]
+name = "libcnb-common"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c4c77089f294316c1d8a285d0ed9973e796a2653c676b22b3f7703d73aa828"
+dependencies = [
+ "serde",
+ "thiserror",
+ "toml 0.8.0",
+]
 
 [[package]]
 name = "libcnb-data"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631bda3e80115baf38894609cde58b796d3b3fc0f47cca369321c230df53d563"
+checksum = "7f35c4af3b47b67257263f0504897cf4db263b407b3e367971fc0b60ada69ce2"
 dependencies = [
  "fancy-regex",
  "libcnb-proc-macros",
  "serde",
  "thiserror",
- "toml",
+ "toml 0.8.0",
  "uriparse",
 ]
 
 [[package]]
 name = "libcnb-package"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f8f85f26a1cacea4c3e3fd01484e2c86ca0d9c252a1e81adb22ab7e5ee0451"
+checksum = "d5ee4c1ac95fc5f71b0f8901d62644f9d39dad0be9d1a5bf23fae173aaf2a46c"
 dependencies = [
  "cargo_metadata",
+ "ignore",
+ "libcnb-common",
  "libcnb-data",
  "petgraph",
- "toml",
+ "thiserror",
+ "uriparse",
  "which",
 ]
 
 [[package]]
 name = "libcnb-proc-macros"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ab33c1d63ffd280516abc7ada744fc1b653a888c439f5e2962d5371d0aecaf7"
+checksum = "5effc8c71a7401899ea2885681b213b779449dc0f581663ea850d9de0718434c"
 dependencies = [
  "cargo_metadata",
  "fancy-regex",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
 
 [[package]]
 name = "log"
@@ -393,12 +475,12 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "petgraph"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
+checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 1.9.3",
+ "indexmap",
 ]
 
 [[package]]
@@ -409,18 +491,18 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.31"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe8a65d69dd0808184ebb5f836ab526bb259db23c657efa38711b1072ee47f0"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -485,10 +567,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
+name = "rustix"
+version = "0.38.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747c788e9ce8e92b12cd485c49ddf90723550b654b32508f979b71a7b1ecda4f"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "semver"
@@ -501,18 +605,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.173"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91f70896d6720bc714a4a57d22fc91f1db634680e65c8efe13323f1fa38d53f"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.173"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6250dde8342e0232232be9ca3db7aa40aceb5a3e5dd9bddbc00d99a007cde49"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -541,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.26"
+version = "2.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c3457aacde3c65315de5031ec191ce46604304d2446e803d71ade03308d970"
+checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -552,22 +656,32 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.43"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
+checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.43"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
+checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -590,7 +704,19 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.19.14",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c226a7bba6d859b63c92c4b4fe69c5b6b72d0cb897dbc8e6012298e6154cb56e"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.20.0",
 ]
 
 [[package]]
@@ -608,7 +734,20 @@ version = "0.19.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ff63e60a958cefbb518ae1fd6566af80d9d4be430a33f3723dfc47d1d411d95"
+dependencies = [
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -635,6 +774,16 @@ checksum = "0200d0fc04d809396c2ad43f3c95da3582a2556eba8d453c1087f4120ee352ff"
 dependencies = [
  "fnv",
  "lazy_static",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -705,13 +854,14 @@ checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "which"
-version = "4.4.0"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
 dependencies = [
  "either",
- "libc",
+ "home",
  "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -731,6 +881,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,6 +900,15 @@ name = "windows"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,12 @@ clap = { version = "4", default-features = false, features = [
     "std",
     "usage",
 ] }
+ignore = "0.4.20"
 indexmap = "2"
 lazy_static = "1"
-libcnb-data = "=0.13.0"
-libcnb-package = "=0.13.0"
+libcnb-common = "=0.15.0"
+libcnb-data = "=0.15.0"
+libcnb-package = "=0.15.0"
 markdown = "1.0.0-alpha.12"
 rand = "0.8"
 regex = "1"

--- a/src/commands/generate_buildpack_matrix/command.rs
+++ b/src/commands/generate_buildpack_matrix/command.rs
@@ -1,34 +1,67 @@
-use crate::buildpacks::{find_releasable_buildpacks, read_image_repository_metadata};
+use crate::buildpacks::{
+    find_releasable_buildpacks, read_buildpack_descriptor, read_image_repository_metadata,
+};
 use crate::commands::generate_buildpack_matrix::errors::Error;
+use crate::commands::get_working_directory;
 use crate::github::actions;
 use clap::Parser;
-use libcnb_package::{
-    get_buildpack_target_dir, read_buildpack_data, BuildpackData, GenericMetadata,
+use libcnb_data::buildpack::{BuildpackDescriptor, BuildpackId};
+use libcnb_package::output::{
+    create_packaged_buildpack_dir_resolver, default_buildpack_directory_name,
 };
+use libcnb_package::CargoProfile;
 use std::collections::{BTreeMap, HashSet};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about = "Generates a JSON list of buildpack information for each buildpack detected", long_about = None)]
-pub(crate) struct GenerateBuildpackMatrixArgs;
+pub(crate) struct GenerateBuildpackMatrixArgs {
+    #[arg(long)]
+    pub(crate) working_directory: Option<PathBuf>,
+    #[arg(long)]
+    pub(crate) package_directory: PathBuf,
+    #[arg(long)]
+    pub release: Option<bool>,
+    #[arg(long, default_value = "x86_64-unknown-linux-musl")]
+    pub target: String,
+}
 
-pub(crate) fn execute(_: GenerateBuildpackMatrixArgs) -> Result<()> {
-    let current_dir = std::env::current_dir().map_err(Error::GetCurrentDir)?;
+pub(crate) fn execute(args: GenerateBuildpackMatrixArgs) -> Result<()> {
+    let working_dir =
+        get_working_directory(args.working_directory).map_err(Error::GetWorkingDirectory)?;
 
-    let buildpack_dirs = find_releasable_buildpacks(&current_dir)
-        .map_err(|e| Error::FindingBuildpacks(current_dir.clone(), e))?;
+    let cargo_profile = if args.release.unwrap_or(true) {
+        CargoProfile::Release
+    } else {
+        CargoProfile::Dev
+    };
+
+    let packaged_buildpack_dir_resolver = create_packaged_buildpack_dir_resolver(
+        &args.package_directory,
+        cargo_profile,
+        &args.target,
+    );
+
+    let buildpack_dirs =
+        find_releasable_buildpacks(&working_dir).map_err(Error::FindReleasableBuildpacks)?;
 
     let buildpacks = buildpack_dirs
         .iter()
-        .map(|dir| read_buildpack_data(dir).map_err(Error::ReadingBuildpackData))
+        .map(|dir| read_buildpack_descriptor(dir).map_err(Error::ReadBuildpackDescriptor))
         .collect::<Result<Vec<_>>>()?;
 
     let includes = buildpack_dirs
         .iter()
         .zip(buildpacks.iter())
-        .map(|(dir, data)| extract_buildpack_info(data, dir, &current_dir))
+        .map(|(buildpack_dir, buildpack_descriptor)| {
+            extract_buildpack_info(
+                buildpack_descriptor,
+                buildpack_dir,
+                &packaged_buildpack_dir_resolver,
+            )
+        })
         .collect::<Result<Vec<_>>>()?;
 
     let includes_json = serde_json::to_string(&includes).map_err(Error::SerializingJson)?;
@@ -37,7 +70,7 @@ pub(crate) fn execute(_: GenerateBuildpackMatrixArgs) -> Result<()> {
 
     let versions = buildpacks
         .iter()
-        .map(|data| data.buildpack_descriptor.buildpack().version.to_string())
+        .map(|buildpack_descriptor| buildpack_descriptor.buildpack().version.to_string())
         .collect::<HashSet<_>>();
 
     if versions.len() != 1 {
@@ -55,45 +88,38 @@ pub(crate) fn execute(_: GenerateBuildpackMatrixArgs) -> Result<()> {
 }
 
 pub(crate) fn extract_buildpack_info(
-    buildpack_data: &BuildpackData<GenericMetadata>,
-    dir: &Path,
-    workspace_dir: &Path,
+    buildpack_descriptor: &BuildpackDescriptor,
+    buildpack_dir: &Path,
+    packaged_buildpack_dir_resolver: &impl Fn(&BuildpackId) -> PathBuf,
 ) -> Result<BTreeMap<String, String>> {
-    let buildpack_dir = dir.to_string_lossy().to_string();
-
-    let buildpack_path = buildpack_data.buildpack_descriptor_path.clone();
-
-    let buildpack_id = buildpack_data.buildpack_descriptor.buildpack().id.clone();
-
-    let buildpack_version = buildpack_data
-        .buildpack_descriptor
-        .buildpack()
-        .version
-        .to_string();
-
-    let buildpack_artifact_prefix = buildpack_id.replace('/', "_");
-
-    let docker_repository = read_image_repository_metadata(&buildpack_data.buildpack_descriptor)
-        .ok_or(Error::MissingDockerRepositoryMetadata(buildpack_path))?;
-
-    let buildpack_output_dir = get_buildpack_target_dir(
-        &buildpack_id,
-        &workspace_dir.to_path_buf().join("target"),
-        true,
-    );
-
     Ok(BTreeMap::from([
-        ("buildpack_id".to_string(), buildpack_id.to_string()),
-        ("buildpack_version".to_string(), buildpack_version),
-        ("buildpack_dir".to_string(), buildpack_dir),
+        (
+            "buildpack_id".to_string(),
+            buildpack_descriptor.buildpack().id.to_string(),
+        ),
+        (
+            "buildpack_version".to_string(),
+            buildpack_descriptor.buildpack().version.to_string(),
+        ),
+        (
+            "buildpack_dir".to_string(),
+            buildpack_dir.to_string_lossy().to_string(),
+        ),
         (
             "buildpack_artifact_prefix".to_string(),
-            buildpack_artifact_prefix,
+            default_buildpack_directory_name(&buildpack_descriptor.buildpack().id),
         ),
         (
             "buildpack_output_dir".to_string(),
-            buildpack_output_dir.to_string_lossy().to_string(),
+            packaged_buildpack_dir_resolver(&buildpack_descriptor.buildpack().id)
+                .to_string_lossy()
+                .to_string(),
         ),
-        ("docker_repository".to_string(), docker_repository),
+        (
+            "docker_repository".to_string(),
+            read_image_repository_metadata(buildpack_descriptor).ok_or(
+                Error::MissingDockerRepositoryMetadata(buildpack_dir.join("buildpack.toml")),
+            )?,
+        ),
     ]))
 }

--- a/src/commands/generate_buildpack_matrix/errors.rs
+++ b/src/commands/generate_buildpack_matrix/errors.rs
@@ -1,40 +1,39 @@
-use crate::github::actions::SetOutputError;
-use libcnb_package::ReadBuildpackDataError;
+use crate::buildpacks::{FindReleasableBuildpacksError, ReadBuildpackDescriptorError};
+use crate::commands::GetWorkingDirectoryError;
+use crate::github::actions::SetActionOutputError;
 use std::collections::HashSet;
 use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
 
 #[derive(Debug)]
 pub(crate) enum Error {
-    GetCurrentDir(std::io::Error),
-    FindingBuildpacks(PathBuf, std::io::Error),
-    ReadingBuildpackData(ReadBuildpackDataError),
+    GetWorkingDirectory(GetWorkingDirectoryError),
+    FindReleasableBuildpacks(FindReleasableBuildpacksError),
+    ReadBuildpackDescriptor(ReadBuildpackDescriptorError),
     MissingDockerRepositoryMetadata(PathBuf),
     SerializingJson(serde_json::Error),
     FixedVersion(HashSet<String>),
-    SetActionOutput(SetOutputError),
+    SetActionOutput(SetActionOutputError),
 }
 
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::GetCurrentDir(error) => {
-                write!(f, "Failed to get current directory\nError: {error}")
+            Error::GetWorkingDirectory(error) => {
+                write!(f, "{error}")
             }
 
-            Error::FindingBuildpacks(path, error) => {
-                write!(
-                    f,
-                    "I/O error while finding buildpacks\nPath: {}\nError: {error}",
-                    path.display()
-                )
+            Error::FindReleasableBuildpacks(error) => {
+                write!(f, "{error}")
             }
 
-            Error::SetActionOutput(set_output_error) => match set_output_error {
-                SetOutputError::Opening(error) | SetOutputError::Writing(error) => {
-                    write!(f, "Could not write action output\nError: {error}")
-                }
-            },
+            Error::SetActionOutput(error) => {
+                write!(f, "{error}")
+            }
+
+            Error::ReadBuildpackDescriptor(error) => {
+                write!(f, "{error}")
+            }
 
             Error::SerializingJson(error) => {
                 write!(
@@ -42,23 +41,6 @@ impl Display for Error {
                     "Could not serialize buildpacks into json\nError: {error}"
                 )
             }
-
-            Error::ReadingBuildpackData(error) => match error {
-                ReadBuildpackDataError::ReadingBuildpack { path, source } => {
-                    write!(
-                        f,
-                        "Failed to read buildpack\nPath: {}\nError: {source}",
-                        path.display()
-                    )
-                }
-                ReadBuildpackDataError::ParsingBuildpack { path, source } => {
-                    write!(
-                        f,
-                        "Failed to parse buildpack\nPath: {}\nError: {source}",
-                        path.display()
-                    )
-                }
-            },
 
             Error::MissingDockerRepositoryMetadata(path) => {
                 write!(

--- a/src/commands/generate_changelog/errors.rs
+++ b/src/commands/generate_changelog/errors.rs
@@ -1,57 +1,38 @@
+use crate::buildpacks::{FindReleasableBuildpacksError, ReadBuildpackDescriptorError};
 use crate::changelog::ChangelogError;
-use crate::github::actions::SetOutputError;
-use libcnb_package::ReadBuildpackDataError;
+use crate::commands::GetWorkingDirectoryError;
+use crate::github::actions::SetActionOutputError;
 use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
 
 #[derive(Debug)]
 pub(crate) enum Error {
-    GetWorkingDir(std::io::Error),
-    FindingBuildpacks(PathBuf, std::io::Error),
-    GetBuildpackId(ReadBuildpackDataError),
+    GetWorkingDir(GetWorkingDirectoryError),
+    FindReleasableBuildpacks(FindReleasableBuildpacksError),
+    ReadBuildpackDescriptor(ReadBuildpackDescriptorError),
     ReadingChangelog(PathBuf, std::io::Error),
     ParsingChangelog(PathBuf, ChangelogError),
-    SetActionOutput(SetOutputError),
+    SetActionOutput(SetActionOutputError),
 }
 
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Error::GetWorkingDir(error) => {
-                write!(f, "Failed to get working directory\nError: {error}")
+                write!(f, "{error}")
             }
 
-            Error::FindingBuildpacks(path, error) => {
-                write!(
-                    f,
-                    "I/O error while finding buildpacks\nPath: {}\nError: {error}",
-                    path.display()
-                )
+            Error::FindReleasableBuildpacks(error) => {
+                write!(f, "{error}")
             }
 
-            Error::GetBuildpackId(read_buildpack_data_error) => match read_buildpack_data_error {
-                ReadBuildpackDataError::ReadingBuildpack { path, source } => {
-                    write!(
-                        f,
-                        "Error reading buildpack\nPath: {}\nError: {source}",
-                        path.display()
-                    )
-                }
+            Error::ReadBuildpackDescriptor(error) => {
+                write!(f, "{error}")
+            }
 
-                ReadBuildpackDataError::ParsingBuildpack { path, source } => {
-                    write!(
-                        f,
-                        "Error parsing buildpack\nPath: {}\nError: {source}",
-                        path.display()
-                    )
-                }
-            },
-
-            Error::SetActionOutput(set_output_error) => match set_output_error {
-                SetOutputError::Opening(error) | SetOutputError::Writing(error) => {
-                    write!(f, "Could not write action output\nError: {error}")
-                }
-            },
+            Error::SetActionOutput(error) => {
+                write!(f, "{error}")
+            }
 
             Error::ReadingChangelog(path, error) => {
                 write!(

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,40 @@
+use std::fmt::{Display, Formatter};
+use std::io;
+use std::path::{Path, PathBuf};
+
 pub(crate) mod generate_buildpack_matrix;
 pub(crate) mod generate_changelog;
 pub(crate) mod prepare_release;
 pub(crate) mod update_builder;
+
+pub(crate) fn resolve_path(path: PathBuf, current_dir: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path
+    } else {
+        current_dir.join(path)
+    }
+}
+
+pub(crate) fn get_working_directory(
+    value: Option<PathBuf>,
+) -> Result<PathBuf, GetWorkingDirectoryError> {
+    std::env::current_dir()
+        .map_err(GetWorkingDirectoryError)
+        .map(|current_dir| {
+            if let Some(dir) = value {
+                resolve_path(dir, &current_dir)
+            } else {
+                current_dir
+            }
+        })
+}
+
+#[derive(Debug)]
+pub(crate) struct GetWorkingDirectoryError(io::Error);
+
+impl Display for GetWorkingDirectoryError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let error = &self.0;
+        write!(f, "Failed to get current directory\nError: {error}")
+    }
+}

--- a/src/commands/update_builder/errors.rs
+++ b/src/commands/update_builder/errors.rs
@@ -1,13 +1,14 @@
-use crate::buildpacks::CalculateDigestError;
-use libcnb_package::ReadBuildpackDataError;
+use crate::buildpacks::{
+    CalculateDigestError, FindReleasableBuildpacksError, ReadBuildpackDescriptorError,
+};
 use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
 
 #[derive(Debug)]
 pub(crate) enum Error {
     GetCurrentDir(std::io::Error),
-    FindingBuildpacks(PathBuf, std::io::Error),
-    ReadingBuildpackData(ReadBuildpackDataError),
+    FindReleasableBuildpacks(FindReleasableBuildpacksError),
+    ReadBuildpackDescriptor(ReadBuildpackDescriptorError),
     NoBuildpacks(PathBuf),
     ReadingBuilder(PathBuf, std::io::Error),
     ParsingBuilder(PathBuf, toml_edit::TomlError),
@@ -61,31 +62,13 @@ impl Display for Error {
                 )
             }
 
-            Error::FindingBuildpacks(path, error) => {
-                write!(
-                    f,
-                    "I/O error while finding buildpacks\nPath: {}\nError: {error}",
-                    path.display()
-                )
+            Error::FindReleasableBuildpacks(error) => {
+                write!(f, "{error}")
             }
 
-            Error::ReadingBuildpackData(error) => match error {
-                ReadBuildpackDataError::ReadingBuildpack { path, source } => {
-                    write!(
-                        f,
-                        "Failed to read buildpack\nPath: {}\nError: {source}",
-                        path.display()
-                    )
-                }
-
-                ReadBuildpackDataError::ParsingBuildpack { path, source } => {
-                    write!(
-                        f,
-                        "Failed to parse buildpack\nPath: {}\nError: {source}",
-                        path.display()
-                    )
-                }
-            },
+            Error::ReadBuildpackDescriptor(error) => {
+                write!(f, "{error}")
+            }
 
             Error::NoBuildpacks(path) => {
                 write!(

--- a/src/github/actions.rs
+++ b/src/github/actions.rs
@@ -1,4 +1,5 @@
 use rand::distributions::{Alphanumeric, DistString};
+use std::fmt::{Display, Formatter};
 use std::fs::OpenOptions;
 use std::io;
 use std::io::{stdout, Write};
@@ -6,7 +7,7 @@ use std::io::{stdout, Write};
 pub(crate) fn set_output<N: Into<String>, V: Into<String>>(
     name: N,
     value: V,
-) -> Result<(), SetOutputError> {
+) -> Result<(), SetActionOutputError> {
     let name = name.into();
     let value = value.into();
 
@@ -23,18 +24,31 @@ pub(crate) fn set_output<N: Into<String>, V: Into<String>>(
             let append_file = OpenOptions::new()
                 .append(true)
                 .open(github_output)
-                .map_err(SetOutputError::Opening)?;
+                .map_err(SetActionOutputError::Opening)?;
             Box::new(append_file)
         }
         Err(_) => Box::new(stdout()),
     };
 
     file.write_all(line.as_bytes())
-        .map_err(SetOutputError::Writing)
+        .map_err(SetActionOutputError::Writing)
 }
 
 #[derive(Debug)]
-pub(crate) enum SetOutputError {
+pub(crate) enum SetActionOutputError {
     Opening(io::Error),
     Writing(io::Error),
+}
+
+impl Display for SetActionOutputError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SetActionOutputError::Opening(error) => {
+                write!(f, "Could not open action output\nError: {error}")
+            }
+            SetActionOutputError::Writing(error) => {
+                write!(f, "Could not write action output\nError: {error}")
+            }
+        }
+    }
 }


### PR DESCRIPTION
The following general improvements were added for all commands:
- Added helpers for determining the working directory if the optional `--working-directory` argument is given
- Added `Display` implementations for errors shared by several commands (i.e.; `FindReleasableBuildpacksError`, `SetActionOutputError`, `GetWorkingDirectoryError`, `ReadBuildpackDescriptor`)

### `generate_buildpack_matrix`

This command has been updated to remove hardcoded target output directories and instead accept a package directory (`--package-dir`). The other (optional) arguments are to line up with the arguments used by `cargo libcnb package` with sensible defaults.

The `_buildpacks_release.yml` workflow has also been updated to pass through the `--package-dir` argument which is set as the default value `./packaged`.

### `generate_changelog`

Slight modifications to support `libcnb` changes and refactorings detailed above.

### `prepare_release`

Slight modifications to support `libcnb` changes and refactorings detailed above.

### `update_builder`

Slight modifications to support `libcnb` changes and refactorings detailed above.

Fixes #125 