### PR TITLE
Add the new builder image variants to the `builder.toml` update list

### DIFF
--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -312,7 +312,7 @@ jobs:
         # image to exist in order to calculate a digest with `crane`. Adding the check here
         # means no files will be modified and so no PR will be created later.
         if: inputs.dry_run == false
-        run: actions update-builder --repository-path ./buildpacks --builder-repository-path ./builder --builders builder-22,buildpacks-20
+        run: actions update-builder --repository-path ./buildpacks --builder-repository-path ./builder --builders builder-20,builder-22,buildpacks-20,salesforce-functions
 
       - name: Create Pull Request
         id: pr


### PR DESCRIPTION
Adds the two new builder image variants recently added to the `heroku/builder` repo:
- https://github.com/heroku/builder/pull/392
- https://github.com/heroku/builder/pull/394

GUS-W-14185090.