### PR TITLE
Update builder repo name to cnb-builder-images

### DIFF
--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -290,11 +290,11 @@ jobs:
         with:
           path: ./buildpacks
 
-      - name: Checkout builder repository
+      - name: Checkout cnb-builder-images repository
         uses: actions/checkout@v4
         with:
-          repository: heroku/builder
-          path: ./builder
+          repository: heroku/cnb-builder-images
+          path: ./cnb-builder-images
           # Using the GH application token here will configure the local git config for this repo with credentials
           # that can be used to make signed commits that are attributed to the GH application user
           token: ${{ steps.generate-token.outputs.app_token }}
@@ -312,7 +312,7 @@ jobs:
         # image to exist in order to calculate a digest with `crane`. Adding the check here
         # means no files will be modified and so no PR will be created later.
         if: inputs.dry_run == false
-        run: actions update-builder --repository-path ./buildpacks --builder-repository-path ./builder --builders builder-20,builder-22,buildpacks-20,salesforce-functions
+        run: actions update-builder --repository-path ./buildpacks --builder-repository-path ./cnb-builder-images --builders builder-20,builder-22,buildpacks-20,salesforce-functions
 
       - name: Create Pull Request
         id: pr
@@ -325,7 +325,7 @@ jobs:
             Update ${{ github.repository }} to v${{ needs.compile.outputs.version }}
 
             ${{ needs.compile.outputs.changelog }}
-          path: ./builder
+          path: ./cnb-builder-images
           branch: update/${{ github.repository }}
           delete-branch: true
           # This will ensure commits made from this workflow are attributed to the GH application user
@@ -334,6 +334,6 @@ jobs:
 
       - name: Configure PR
         if: steps.pr.outputs.pull-request-operation == 'created'
-        run: gh pr merge --auto --squash --repo heroku/builder "${{ steps.pr.outputs.pull-request-number }}"
+        run: gh pr merge --auto --squash --repo heroku/cnb-builder-images "${{ steps.pr.outputs.pull-request-number }}"
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.app_token }}

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Performs the release steps for one or more buildpacks by:
     > repository = "{repository_url}"
     > ```
   * Retrieving the OCI image url published to Docker Hub and registering this with the CNB Registry
-* Once all buildpacks have been published, all the buildpack references found in [heroku/builder](https://github.com/heroku/builder)
+* Once all buildpacks have been published, all the buildpack references found in [heroku/cnb-builder-images](https://github.com/heroku/cnb-builder-images)
   are updated for the given list of builders and a pull request is opened containing all the changes to be committed.
 
 You can pin to:
@@ -185,6 +185,6 @@ Commands:
   generate-buildpack-matrix  Generates a JSON list of buildpack information for each buildpack detected
   generate-changelog         Generates a changelog from one or more buildpacks in a project
   prepare-release            Bumps the version of each detected buildpack and adds an entry for any unreleased changes from the changelog
-  update-builder             Updates all references to a buildpack in heroku/builder for the given list of builders
+  update-builder             Updates all references to a buildpack in heroku/cnb-builder-images for the given list of builders
   help                       Print this message or the help of the given subcommand(s)
 ```

--- a/src/commands/update_builder/command.rs
+++ b/src/commands/update_builder/command.rs
@@ -13,7 +13,7 @@ use uriparse::URI;
 type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Parser, Debug)]
-#[command(author, version, about = "Updates all references to a buildpack in heroku/builder for the given list of builders", long_about = None)]
+#[command(author, version, about = "Updates all references to a buildpack in heroku/cnb-builder-images for the given list of builders", long_about = None)]
 pub(crate) struct UpdateBuilderArgs {
     #[arg(long)]
     pub(crate) repository_path: String,


### PR DESCRIPTION
Since the repository has been renamed:
https://github.com/heroku/cnb-builder-images/issues/396

GUS-W-14201543.