### PR TITLE
Apply some reliability/failure UX best practices

### DIFF
--- a/.github/workflows/_buildpacks-prepare-release.yml
+++ b/.github/workflows/_buildpacks-prepare-release.yml
@@ -1,8 +1,5 @@
 name: _buildpacks-prepare-release
 
-env:
-  CARGO_TERM_COLOR: always
-
 on:
   workflow_call:
     inputs:
@@ -44,6 +41,16 @@ on:
       app_private_key:
         description: Private key of GitHub application (Linguist)
         required: true
+
+defaults:
+  run:
+    # Setting an explicit bash shell ensures GitHub Actions enables pipefail mode too,
+    # ratherthan only error on exit (improving failure UX when pipes are used). See:
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
+    shell: bash
+
+env:
+  CARGO_TERM_COLOR: always
 
 jobs:
   prepare-release:

--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -1,8 +1,5 @@
 name: _buildpacks-release
 
-env:
-  CARGO_TERM_COLOR: always
-
 on:
   workflow_call:
     inputs:
@@ -48,6 +45,16 @@ on:
       docker_hub_token:
         required: true
         description: The token to login to Docker Hub with
+
+defaults:
+  run:
+    # Setting an explicit bash shell ensures GitHub Actions enables pipefail mode too,
+    # ratherthan only error on exit (improving failure UX when pipes are used). See:
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
+    shell: bash
+
+env:
+  CARGO_TERM_COLOR: always
 
 jobs:
   compile:
@@ -112,9 +119,9 @@ jobs:
           bash_buildpack_output_dirs=()
 
           # copy any bash-based buildpack to target buildpack dir because `cargo libcnb package` will ignore them
-          for buildpack in $(jq -c '.[]' <<< "${buildpacks}"); do
-            buildpack_dir=$(jq -r '.buildpack_dir' <<< "${buildpack}")
-            output_dir=$(jq -r '.buildpack_output_dir' <<< "${buildpack}")
+          for buildpack in $(jq --exit-status -c '.[]' <<< "${buildpacks}"); do
+            buildpack_dir=$(jq --exit-status -r '.buildpack_dir' <<< "${buildpack}")
+            output_dir=$(jq --exit-status -r '.buildpack_output_dir' <<< "${buildpack}")
             if [ ! -d "${output_dir}" ]; then
               echo "bash-based buildpack detected at ${buildpack_dir}"
               cp -R "${buildpack_dir}" "${output_dir}"
@@ -124,8 +131,8 @@ jobs:
           done
 
           # replace dependencies that reference a bash-buildpack
-          for buildpack in $(jq -c '.[]' <<< "${buildpacks}"); do
-            output_dir=$(jq -r '.buildpack_output_dir' <<< "${buildpack}")
+          for buildpack in $(jq --exit-status -c '.[]' <<< "${buildpacks}"); do
+            output_dir=$(jq --exit-status -r '.buildpack_output_dir' <<< "${buildpack}")
             echo "checking dependencies in ${output_dir}/package.toml"
             for dep in $(yq -oy '.dependencies[].uri' "${output_dir}/package.toml"); do
               if realpath "${dep}" &> /dev/null; then
@@ -209,9 +216,9 @@ jobs:
 
       - name: Generate CNB files
         run: |
-          for buildpack in $(jq -c '.[]' <<< '${{ needs.compile.outputs.buildpacks }}'); do
-            artifact_prefix=$(jq -r '.buildpack_artifact_prefix' <<< "${buildpack}")
-            output_dir=$(jq -r '.buildpack_output_dir' <<< "${buildpack}")
+          for buildpack in $(jq --exit-status -c '.[]' <<< '${{ needs.compile.outputs.buildpacks }}'); do
+            artifact_prefix=$(jq --exit-status -r '.buildpack_artifact_prefix' <<< "${buildpack}")
+            output_dir=$(jq --exit-status -r '.buildpack_output_dir' <<< "${buildpack}")
             pack buildpack package "${artifact_prefix}.cnb" --config "${output_dir}/package.toml" --format file --verbose
           done
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
   push:
     branches: ["main"]
 
+defaults:
+  run:
+    # Setting an explicit bash shell ensures GitHub Actions enables pipefail mode too,
+    # ratherthan only error on exit (improving failure UX when pipes are used). See:
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
+    shell: bash
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,5 @@
 name: Release Actions
 
-env:
-  CARGO_TERM_COLOR: always
-
 on:
   workflow_dispatch:
     inputs:
@@ -15,6 +12,16 @@ on:
           - major
           - minor
           - patch
+
+defaults:
+  run:
+    # Setting an explicit bash shell ensures GitHub Actions enables pipefail mode too,
+    # ratherthan only error on exit (improving failure UX when pipes are used). See:
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
+    shell: bash
+
+env:
+  CARGO_TERM_COLOR: always
 
 jobs:
   prepare:
@@ -52,9 +59,9 @@ jobs:
 
       - name: Get previous release version
         id: previous-version
+        run: echo "value=$(gh release view --json tagName --jq '.tagName' | sed 's/^v//')" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.app_token }}
-        run: echo "value=$(gh release view --json tagName --jq '.tagName' | sed 's/^v//')" >> $GITHUB_OUTPUT
 
       - name: Bump version
         run: |
@@ -67,8 +74,8 @@ jobs:
       - name: Get release metadata
         id: metadata
         run: |
-          echo "name=$(cargo metadata --format-version=1 --no-deps | jq -r '.packages[-1].targets[-1].name')" >> $GITHUB_OUTPUT
-          echo "version=$(cargo metadata --format-version=1 --no-deps | jq -r '.packages[-1].version')" >> $GITHUB_OUTPUT
+          echo "name=$(cargo metadata --format-version=1 --no-deps | jq --exit-status -r '.packages[-1].targets[-1].name')" >> $GITHUB_OUTPUT
+          echo "version=$(cargo metadata --format-version=1 --no-deps | jq --exit-status -r '.packages[-1].version')" >> $GITHUB_OUTPUT
 
       - name: Package binary
         id: package-binary


### PR DESCRIPTION
- Enable Bash `pipefail` mode by setting an explicit GitHub Actions shell
- Pass `--exit-status` to all `jq` invocations, so it actually exits non-zero on empty input

See:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell https://jqlang.github.io/jq/manual/#invoking-jq

GUS-W-14249448.