### PR TITLE
Fix lint errors in Rust 1.73 and 1.74

### DIFF
--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -48,9 +48,8 @@ impl TryFrom<&str> for Changelog {
                         }
                         Ordering::Greater => {
                             if let Some(header) = &current_header {
-                                let body_nodes = body_nodes_by_header
-                                    .entry(header.clone())
-                                    .or_insert_with(Vec::new);
+                                let body_nodes =
+                                    body_nodes_by_header.entry(header.clone()).or_default();
                                 body_nodes.push(child);
                             }
                         }
@@ -58,9 +57,7 @@ impl TryFrom<&str> for Changelog {
                 } else if let Node::Definition(_) = child {
                     // ignore any defined links, these will be regenerated at display time
                 } else if let Some(header) = &current_header {
-                    let body_nodes = body_nodes_by_header
-                        .entry(header.clone())
-                        .or_insert_with(Vec::new);
+                    let body_nodes = body_nodes_by_header.entry(header.clone()).or_default();
                     body_nodes.push(child);
                 }
             }
@@ -137,14 +134,14 @@ impl Display for Changelog {
         write!(
             f,
             "{}",
-            r#"
+            r"
 # Changelog
 
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-        "#
+        "
             .trim()
         )?;
 
@@ -424,7 +421,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
         );
         assert_eq!(
             declarations,
-            r#"[unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.1.1...HEAD
+            r"[unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.1.1...HEAD
 [1.1.1]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.3.0...v1.0.0
@@ -438,7 +435,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.0.4]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.3...v0.0.4
 [0.0.3]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.2...v0.0.3
 [0.0.2]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.1...v0.0.2
-[0.0.1]: https://github.com/olivierlacan/keep-a-changelog/releases/tag/v0.0.1"#
+[0.0.1]: https://github.com/olivierlacan/keep-a-changelog/releases/tag/v0.0.1"
         );
     }
 
@@ -488,10 +485,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
         );
         assert_eq!(
             declarations,
-            r#"[unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.1.1...HEAD
+            r"[unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.1.1...HEAD
 [1.1.1]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.0.0...v1.1.0
-[1.0.0]: https://github.com/olivierlacan/keep-a-changelog/releases/tag/v1.0.0"#
+[1.0.0]: https://github.com/olivierlacan/keep-a-changelog/releases/tag/v1.0.0"
         );
     }
 

--- a/src/commands/generate_changelog/command.rs
+++ b/src/commands/generate_changelog/command.rs
@@ -145,7 +145,7 @@ mod test {
 
         assert_eq!(
             generate_changelog(&values),
-            r#"## a
+            r"## a
 
 - change a.1
 - change a.2
@@ -158,7 +158,7 @@ mod test {
 
 - No changes.
 
-"#
+"
         );
     }
 }

--- a/src/commands/prepare_release/command.rs
+++ b/src/commands/prepare_release/command.rs
@@ -779,7 +779,7 @@ optional = true
     ) {
         let changelog = Changelog {
             unreleased: Some(
-                r#"
+                r"
 - Entry not under a header
 
 ### Added
@@ -794,7 +794,7 @@ optional = true
 ### Removed
 
 - Dropped all deprecated methods
-                "#
+                "
                 .trim()
                 .to_string(),
             ),
@@ -818,7 +818,7 @@ optional = true
         assert_eq!(changelog.unreleased, None);
         assert_eq!(
             changelog.releases.get("0.8.17").unwrap().body,
-            r#"
+            r"
 - Entry not under a header
 
 ### Added
@@ -835,7 +835,7 @@ optional = true
 ### Removed
 
 - Dropped all deprecated methods
-            "#
+            "
             .trim()
             .to_string()
         );


### PR DESCRIPTION
Fixes the following which are new in Rust 1.73:

```
error: use of `or_insert_with` to construct default value
  --> src/changelog.rs:53:38
   |
53 | ...                   .or_insert_with(Vec::new);
   |                        ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unwrap_or_default
   = note: `-D clippy::unwrap-or-default` implied by `-D warnings`

error: use of `or_insert_with` to construct default value
  --> src/changelog.rs:63:26
   |
63 |                         .or_insert_with(Vec::new);
   |                          ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unwrap_or_default
```

And these from Rust 1.74 (only showing first error):

```
warning: unnecessary hashes around raw string literal
   --> src/changelog.rs:140:13
    |
140 | /             r#"
141 | | # Changelog
142 | |
143 | | All notable changes to this project will be documented in this file.
...   |
146 | | and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
147 | |         "#
    | |__________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_raw_string_hashes
...
```

GUS-W-14249468.