### PR TITLE
Add `heroku/builder-classic:22` to the builder.toml update list

### DIFF
--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -320,7 +320,7 @@ jobs:
         # image to exist in order to calculate a digest with `crane`. Adding the check here
         # means no files will be modified and so no PR will be created later.
         if: inputs.dry_run == false
-        run: actions update-builder --repository-path ./buildpacks --builder-repository-path ./cnb-builder-images --builders builder-20,builder-22,buildpacks-20,salesforce-functions
+        run: actions update-builder --repository-path ./buildpacks --builder-repository-path ./cnb-builder-images --builders builder-20,builder-22,builder-classic-22,buildpacks-20,salesforce-functions
 
       - name: Create Pull Request
         id: pr


### PR DESCRIPTION
Since whilst it primarily contains shimmed CNBs (which do not need updating), it does contain a single non-shimmed CNB - the Procfile CNB.

Currently this builder is not being updated for new Procfile CNB releases, meaning it's now on an older version of it than the other builder images.