### PR TITLE
Fix error message shown when image repository metadata is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ Performs the release steps for one or more buildpacks by:
     > The following metadata is used for declaring the registry:
     >
     > ```toml
-    > [metadata.release.image]
-    > repository = "{repository_url}"
+    > [metadata.release]
+    > image = { repository = "docker.io/heroku/buildpack-example" }
     > ```
   * Retrieving the OCI image url published to Docker Hub and registering this with the CNB Registry
 * Once all buildpacks have been published, all the buildpack references found in [heroku/cnb-builder-images](https://github.com/heroku/cnb-builder-images)

--- a/src/buildpacks.rs
+++ b/src/buildpacks.rs
@@ -41,7 +41,7 @@ pub(crate) fn read_image_repository_metadata(
         .as_ref()
         .and_then(|metadata| metadata.get("release").and_then(|value| value.as_table()))
         .and_then(|release| release.get("image").and_then(|value| value.as_table()))
-        .and_then(|docker| docker.get("repository").and_then(|value| value.as_str()))
+        .and_then(|image| image.get("repository").and_then(|value| value.as_str()))
         .map(|value| value.to_string())
 }
 

--- a/src/commands/generate_buildpack_matrix/command.rs
+++ b/src/commands/generate_buildpack_matrix/command.rs
@@ -105,7 +105,7 @@ pub(crate) fn extract_buildpack_info(
         (
             "docker_repository".to_string(),
             read_image_repository_metadata(buildpack_descriptor).ok_or(
-                Error::MissingDockerRepositoryMetadata(buildpack_dir.join("buildpack.toml")),
+                Error::MissingImageRepositoryMetadata(buildpack_dir.join("buildpack.toml")),
             )?,
         ),
     ]))

--- a/src/commands/generate_buildpack_matrix/errors.rs
+++ b/src/commands/generate_buildpack_matrix/errors.rs
@@ -11,8 +11,8 @@ pub(crate) enum Error {
     FindReleasableBuildpacks(FindReleasableBuildpacksError),
     #[error(transparent)]
     ReadBuildpackDescriptor(ReadBuildpackDescriptorError),
-    #[error("The following buildpack is missing the metadata.release.docker.repository entry\nPath: {}", .0.display())]
-    MissingDockerRepositoryMetadata(PathBuf),
+    #[error("The following buildpack is missing the metadata.release.image.repository entry\nPath: {}", .0.display())]
+    MissingImageRepositoryMetadata(PathBuf),
     #[error("Could not serialize buildpacks into json\nError: {0}")]
     SerializingJson(#[source] serde_json::Error),
     #[error("Expected all buildpacks to have the same version but multiple versions were found:\n{}", list_versions(.0))]

--- a/src/commands/update_builder/command.rs
+++ b/src/commands/update_builder/command.rs
@@ -74,7 +74,7 @@ pub(crate) fn execute(args: UpdateBuilderArgs) -> Result<()> {
             let buildpack_version = &buildpack_descriptor.buildpack().version;
 
             let docker_repository = read_image_repository_metadata(buildpack_descriptor).ok_or(
-                Error::MissingDockerRepositoryMetadata(buildpack_path.clone()),
+                Error::MissingImageRepositoryMetadata(buildpack_path.clone()),
             )?;
 
             let buildpack_uri =

--- a/src/commands/update_builder/errors.rs
+++ b/src/commands/update_builder/errors.rs
@@ -21,8 +21,8 @@ pub(crate) enum Error {
     WritingBuilder(PathBuf, #[source] std::io::Error),
     #[error("No builder.toml files found in the given builder directories\n{}", list_builders(.0))]
     NoBuilderFiles(Vec<String>),
-    #[error("The following buildpack is missing the metadata.release.docker.repository entry\nPath: {}", .0.display())]
-    MissingDockerRepositoryMetadata(PathBuf),
+    #[error("The following buildpack is missing the metadata.release.image.repository entry\nPath: {}", .0.display())]
+    MissingImageRepositoryMetadata(PathBuf),
     #[error("Failed to calculate digest for buildpack\nPath: {}\nError: {1}", .0.display())]
     CalculatingDigest(PathBuf, #[source] CalculateDigestError),
     #[error("Missing required key `{0}` in builder")]


### PR DESCRIPTION
As of #88 the metadata is now under `image.repository` not `docker.repository`, however, the error message still referenced the old location.

This caused confusion in when debugging heroku/buildpacks-jvm#60: https://github.com/heroku/buildpacks-jvm/actions/runs/6626786735/job/18000413851#step:10:10

In addition to fixing the error message, I've renamed the enum variants and variables to match the new name.

Lastly, I've updated the README to match the more concise release metadata style now used by all of our buildpacks (the repository URL is also a real example, to make it clearer that the URL shouldn't include the `docker://` prefix).

Fixes #168.
GUS-W-14355165.