### PR TITLE
Switch to Cargo.toml based lint configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "languages-github-actions"
 description = "GitHub Actions for the Languages Team"
 version = "0.0.1"
 repository = "https://github.com/heroku/languages-github-actions.git"
-rust-version = "1.66"
+rust-version = "1.74"
 edition = "2021"
 publish = false
 
@@ -13,6 +13,12 @@ path = "src/main.rs"
 
 [profile.release]
 strip = true
+
+[lints.rust]
+unused_crate_dependencies = "warn"
+
+[lints.clippy]
+pedantic = "warn"
 
 [dependencies]
 chrono = "0.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,3 @@
-#![warn(clippy::pedantic)]
-#![warn(unused_crate_dependencies)]
-
 use crate::commands::generate_buildpack_matrix::command::GenerateBuildpackMatrixArgs;
 use crate::commands::generate_changelog::command::GenerateChangelogArgs;
 use crate::commands::prepare_release::command::PrepareReleaseArgs;


### PR DESCRIPTION
As of the Cargo included in Rust 1.74, lints can now be configured in `Cargo.toml` across whole crates/workspaces:
https://blog.rust-lang.org/2023/11/16/Rust-1.74.0.html
https://doc.rust-lang.org/stable/cargo/reference/manifest.html#the-lints-section

Since this feature requires Rust 1.74, the MSRV has also been bumped.

GUS-W-14523770.