### PR TITLE
Enable additional rustc and Clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,14 @@ path = "src/main.rs"
 strip = true
 
 [lints.rust]
+unreachable_pub = "warn"
+unsafe_code = "warn"
 unused_crate_dependencies = "warn"
 
 [lints.clippy]
+panic_in_result_fn = "warn"
 pedantic = "warn"
+unwrap_used = "warn"
 
 [dependencies]
 chrono = "0.4"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+allow-unwrap-in-tests = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ const UNSPECIFIED_ERROR: i32 = 1;
 
 #[derive(Parser)]
 #[command(bin_name = "actions")]
-pub(crate) enum Cli {
+enum Cli {
     GenerateBuildpackMatrix(GenerateBuildpackMatrixArgs),
     GenerateChangelog(GenerateChangelogArgs),
     PrepareRelease(PrepareReleaseArgs),


### PR DESCRIPTION
Enables some off-by-default lints that we already use in the `libcnb.rs` repository.

https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unreachable-pub
https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unsafe-code
https://rust-lang.github.io/rust-clippy/master/index.html#/panic_in_result_fn
https://rust-lang.github.io/rust-clippy/master/index.html#/unwrap_used

GUS-W-14523770.