### PR TITLE
Simplify Cargo metadata for `publish = false` crates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /.idea
+.DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "languages-github-actions"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,7 @@
 [package]
 name = "languages-github-actions"
-description = "GitHub Actions for the Languages Team"
-version = "0.0.1"
-repository = "https://github.com/heroku/languages-github-actions.git"
-rust-version = "1.74"
+rust-version = "1.75"
 edition = "2021"
-publish = false
 
 [[bin]]
 name = "actions"


### PR DESCRIPTION
As of Cargo 1.75 the `version` property in `Cargo.toml` is now optional, and if omitted is the same as having specified `version = "0.0.0"` and `publish = false`:
https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-175-2023-12-28
https://doc.rust-lang.org/cargo/reference/manifest.html#the-version-field

Therefore for crates that we do not publish, we can now remove both the `version` and `publish` properties, avoiding the need for the fake `0.0.0` version that differs from the actual buildpack version in `buildpack.toml`.

GUS-W-14821120.