### PR TITLE
Add back the `version` field to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,10 @@
 name = "languages-github-actions"
 rust-version = "1.75"
 edition = "2021"
+# This crate isn't published to crates.io, however, we still need the version field here,
+# since it's updated to the real version as part of tagging/publishing to GitHub releases.
+version = "0.0.0"
+publish = false
 
 [[bin]]
 name = "actions"


### PR DESCRIPTION
The `version` and `publish` fields were removed in #181 since they are now optional for crates that are not published to crates.io.

However, even though this crate isn't published to crates.io, the `version` field is still used/set as part of the current GitHub Releases publishing process, which uses `cargo-bump` to generate an appropriate new version number based on the major/minor/patch workflow input.

Fixes:

```
$ cargo bump 0.3.10
thread 'main' panicked at /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-bump-1.1.0/src/main.rs:57:14:
toml has version
```

Seen in:
https://github.com/heroku/languages-github-actions/actions/runs/7669085052/job/20902261440#step:9:10