### PR TITLE
Fix multi-line `GITHUB_OUTPUT` error in classic buildpack prepare release workflow

### DIFF
--- a/.github/workflows/_classic-buildpack-prepare-release.yml
+++ b/.github/workflows/_classic-buildpack-prepare-release.yml
@@ -74,7 +74,13 @@ jobs:
 
       - name: Generate list of unreleased commits
         id: unreleased-commits
-        run: echo "commits=$(git log --topo-order --reverse --format='- %s' v${{ steps.existing-version.outputs.version }}...main)" >> "${GITHUB_OUTPUT}"
+        # See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+        run: |
+          {
+            echo 'commits<<COMMITS_LIST_END'
+            git log --topo-order --reverse --format='- %s' v${{ steps.existing-version.outputs.version }}...main
+            echo COMMITS_LIST_END
+          } >> "${GITHUB_OUTPUT}"
 
       - name: Create pull request
         id: pr


### PR DESCRIPTION
Currently if the `git log` generated to populate the PR description contains more than one commit, the workflow fails with errors like:

```
Error: Unable to process file command 'output' successfully.
Error: Invalid format '- Migrate from CircleCI to GHA (#214)'
```

This is because of the GitHub Actions gotcha around multi-line strings when using `GITHUB_OUTPUT` (or `GITHUB_ENV`):
https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings

This didn't come up during testing, since the repo I tried with happened to only have a single commit on `main` since the last tag, and so didn't generate a multi-line `git log` output.

See also:
https://github.com/heroku/heroku-buildpack-nodejs/pull/1153
https://github.com/heroku/libcnb.rs/pull/692

GUS-W-14894410.