### PR TITLE
Add builder-24 to the list of builder manifests that are updated

### DIFF
--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -403,7 +403,7 @@ jobs:
         # image to exist in order to calculate a digest with `crane`. Adding the check here
         # means no files will be modified and so no PR will be created later.
         if: inputs.dry_run == false
-        run: actions update-builder --repository-path ./buildpacks --builder-repository-path ./cnb-builder-images --builders builder-20,builder-22,builder-classic-22,buildpacks-20,salesforce-functions
+        run: actions update-builder --repository-path ./buildpacks --builder-repository-path ./cnb-builder-images --builders builder-20,builder-22,builder-24,builder-classic-22,buildpacks-20,salesforce-functions
 
       - name: Create Pull Request
         id: pr


### PR DESCRIPTION
Now that we have the new Heroku-24 based builder (as of https://github.com/heroku/cnb-builder-images/pull/504), we should keep it up to date with releases, like we do for the other builders.

GUS-W-14673590.