### PR TITLE
Stop updating manifests of legacy builders

### DIFF
--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -403,7 +403,7 @@ jobs:
         # image to exist in order to calculate a digest with `crane`. Adding the check here
         # means no files will be modified and so no PR will be created later.
         if: inputs.dry_run == false
-        run: actions update-builder --repository-path ./buildpacks --builder-repository-path ./cnb-builder-images --builders builder-20,builder-22,builder-24,builder-classic-22,buildpacks-20,salesforce-functions
+        run: actions update-builder --repository-path ./buildpacks --builder-repository-path ./cnb-builder-images --builders builder-20,builder-22,builder-24,salesforce-functions
 
       - name: Create Pull Request
         id: pr


### PR DESCRIPTION
Since we no longer want to be publishing new versions of the legacy builders, and so the manifests for them are being removed from the builder repo in:
https://github.com/heroku/cnb-builder-images/pull/514

GUS-W-15677907.