### PR TITLE
Use actions/create-github-app-token instead of heroku/use-app-token

### DIFF
--- a/.github/workflows/_buildpacks-prepare-release.yml
+++ b/.github/workflows/_buildpacks-prepare-release.yml
@@ -58,18 +58,18 @@ jobs:
     runs-on: ${{ inputs.ip_allowlisted_runner }}
     steps:
       - name: Get token for GH application (Linguist)
-        uses: heroku/use-app-token-action@main
+        uses: actions/create-github-app-token@v1
         id: generate-token
         with:
-          app_id: ${{ inputs.app_id }}
-          private_key: ${{ secrets.app_private_key }}
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.app_private_key }}
 
       - name: Checkout
         uses: actions/checkout@v4
         with:
           # Using the GH application token here will configure the local git config for this repo with credentials
           # that can be used to make signed commits that are attributed to the GH application user
-          token: ${{ steps.generate-token.outputs.app_token }}
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Install Languages CLI
         uses: heroku/languages-github-actions/.github/actions/install-languages-cli@main
@@ -92,7 +92,7 @@ jobs:
         id: pr
         uses: peter-evans/create-pull-request@v6.0.5
         with:
-          token: ${{ steps.generate-token.outputs.app_token }}
+          token: ${{ steps.generate-token.outputs.token }}
           title: Prepare release v${{ steps.prepare.outputs.to_version }}
           body: ${{ steps.generate-changelog.outputs.changelog }}
           commit-message: |
@@ -109,4 +109,4 @@ jobs:
         if: steps.pr.outputs.pull-request-operation == 'created'
         run: gh pr merge --auto --squash "${{ steps.pr.outputs.pull-request-number }}"
         env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.app_token }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -307,23 +307,23 @@ jobs:
           done
 
       - name: Get token for GitHub application (Linguist)
-        uses: heroku/use-app-token-action@main
+        uses: actions/create-github-app-token@v1
         id: generate-token
         with:
-          app_id: ${{ inputs.app_id }}
-          private_key: ${{ secrets.app_private_key }}
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.app_private_key }}
 
       - name: Check if release exists
         id: check
         env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.app_token }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: echo "published_to_github=$(gh release view v${{ needs.compile.outputs.version }} -R ${{ github.repository }} &> /dev/null && echo "true" || echo "false")" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
         if: inputs.dry_run == false && steps.check.outputs.published_to_github == 'false'
         uses: softprops/action-gh-release@v2.0.4
         with:
-          token: ${{ steps.generate-token.outputs.app_token }}
+          token: ${{ steps.generate-token.outputs.token }}
           tag_name: v${{ needs.compile.outputs.version }}
           body: ${{ needs.compile.outputs.changelog }}
           files: "*.cnb"
@@ -370,11 +370,11 @@ jobs:
     runs-on: ${{ inputs.ip_allowlisted_runner }}
     steps:
       - name: Get token for GH application (Linguist)
-        uses: heroku/use-app-token-action@main
+        uses: actions/create-github-app-token@v1
         id: generate-token
         with:
-          app_id: ${{ inputs.app_id }}
-          private_key: ${{ secrets.app_private_key }}
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.app_private_key }}
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -388,7 +388,7 @@ jobs:
           path: ./cnb-builder-images
           # Using the GH application token here will configure the local git config for this repo with credentials
           # that can be used to make signed commits that are attributed to the GH application user
-          token: ${{ steps.generate-token.outputs.app_token }}
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Install crane
         uses: buildpacks/github-actions/setup-tools@v5.6.0
@@ -409,7 +409,7 @@ jobs:
         id: pr
         uses: peter-evans/create-pull-request@v6.0.5
         with:
-          token: ${{ steps.generate-token.outputs.app_token }}
+          token: ${{ steps.generate-token.outputs.token }}
           title: Update ${{ github.repository }} to v${{ needs.compile.outputs.version }}
           body: ${{ needs.compile.outputs.changelog }}
           commit-message: |
@@ -427,4 +427,4 @@ jobs:
         if: steps.pr.outputs.pull-request-operation == 'created'
         run: gh pr merge --auto --squash --repo heroku/cnb-builder-images "${{ steps.pr.outputs.pull-request-number }}"
         env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.app_token }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -375,6 +375,7 @@ jobs:
         with:
           app-id: ${{ inputs.app_id }}
           private-key: ${{ secrets.app_private_key }}
+          repositories: heroku/cnb-builder-images
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/_classic-buildpack-prepare-release.yml
+++ b/.github/workflows/_classic-buildpack-prepare-release.yml
@@ -24,13 +24,13 @@ jobs:
       # workflows (such as CI) won't automatically run on any PRs opened by this workflow:
       # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
       - name: Generate access token for Linguist GitHub App
-        uses: heroku/use-app-token-action@main
+        uses: actions/create-github-app-token@v1
         id: generate-token
         with:
-          app_id: ${{ vars.LINGUIST_GH_APP_ID }}
+          app-id: ${{ vars.LINGUIST_GH_APP_ID }}
           # Note: The calling workflow must enable secrets inheritance for this variable to be accessible:
           # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idsecretsinherit
-          private_key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}
+          private-key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
           # Force a full clone, otherwise fetch-tags doesn't actually fetch any tags:
           # https://github.com/actions/checkout/issues/1471
           fetch-depth: 0
-          token: ${{ steps.generate-token.outputs.app_token }}
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Determine existing tagged version
         id: existing-version
@@ -86,7 +86,7 @@ jobs:
         id: pr
         uses: peter-evans/create-pull-request@v6.0.5
         with:
-          token: ${{ steps.generate-token.outputs.app_token }}
+          token: ${{ steps.generate-token.outputs.token }}
           title: Prepare release v${{ steps.new-version.outputs.version }}
           body: |
             Commits since the last release:
@@ -107,4 +107,4 @@ jobs:
         if: steps.pr.outputs.pull-request-operation == 'created'
         run: gh pr merge --auto --squash "${{ steps.pr.outputs.pull-request-number }}"
         env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.app_token }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,18 +29,18 @@ jobs:
     runs-on: pub-hk-ubuntu-22.04-small
     steps:
       - name: Get token for GH application (Linguist)
-        uses: heroku/use-app-token-action@main
+        uses: actions/create-github-app-token@v1
         id: generate-token
         with:
-          app_id: ${{ vars.LINGUIST_GH_APP_ID }}
-          private_key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}
+          app-id: ${{ vars.LINGUIST_GH_APP_ID }}
+          private-key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}
 
       - name: Checkout
         uses: actions/checkout@v4
         with:
           # Using the GH application token here will configure the local git config for this repo with credentials
           # that can be used to make signed commits that are attributed to the GH application user
-          token: ${{ steps.generate-token.outputs.app_token }}
+          token: ${{ steps.generate-token.outputs.token }}
 
       # This will ensure commits made from this workflow are attributed to the GH application user
       - name: Configure git
@@ -61,7 +61,7 @@ jobs:
         id: previous-version
         run: echo "value=$(gh release view --json tagName --jq '.tagName' | sed 's/^v//')" >> $GITHUB_OUTPUT
         env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.app_token }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
 
       - name: Bump version
         run: |
@@ -122,7 +122,7 @@ jobs:
       - name: Create release
         uses: softprops/action-gh-release@v2.0.4
         env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.app_token }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         with:
           target_commitish: ${{ steps.release-tag.outputs.sha }}
           tag_name: v${{ steps.metadata.outputs.version }}


### PR DESCRIPTION
The use-app-token action is deprecated: https://github.com/heroku/use-app-token-action/pull/17

Throws a warning on actions that use it:

<img width="1080" alt="Screenshot 2024-05-29 at 21 04 48" src="https://github.com/heroku/languages-github-actions/assets/27900/d73c5548-5bd5-4a0b-9102-cad77f556f06">

GUS-W-15886232