### PR TITLE
Downgrade to request-add-entry Action v5.6.1

### DIFF
--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -357,7 +357,7 @@ jobs:
 
       - name: Register the new version with the CNB Buildpack Registry
         if: inputs.dry_run == false && steps.check.outputs.published_to_cnb_registry == 'false'
-        uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:5.7.1
+        uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:5.6.1
         with:
           token: ${{ secrets.cnb_registry_token }}
           id: ${{ matrix.buildpack_id }}


### PR DESCRIPTION
Since upstream image publishing is broken and the images for the new versions haven't been published/tagged properly: https://cloud-native.slack.com/archives/C032YE21V1T/p1717723450552739
https://github.com/orgs/buildpacks/packages/container/actions%2Fregistry%2Frequest-add-entry/versions?filters%5Bversion_type%5D=tagged

This will be fixed upstream by:
https://github.com/buildpacks/github-actions/pull/284

However, in the meantime we can use the old version.