### PR TITLE
Set target when packaging buildpack

### DIFF
--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -302,7 +302,8 @@ jobs:
             for target in $(jq --exit-status -c ".targets | .[]" <<< "${buildpack}"); do
               output_dir=$(jq --exit-status -r ".output_dir" <<< "${target}")
               cnb_file=$(jq --exit-status -r ".cnb_file" <<< "${target}")
-              pack buildpack package "$cnb_file" --config "${output_dir}/package.toml" --format file --verbose
+              oci_target=$(jq --exit-status -r ".oci_target" <<< "${target}")
+              pack buildpack package "$cnb_file" --target "${oci_target}" --config "${output_dir}/package.toml" --format file --verbose
             done
           done
 


### PR DESCRIPTION
We're seeing some releases with extra `{os}-{arch}` suffixes on the `.cnb` files, and duplicated copies of `.cnb` files:

- https://github.com/heroku/buildpacks-procfile/releases/tag/v3.1.2
- https://github.com/heroku/buildpacks-python/releases/tag/v0.11.0
- https://github.com/heroku/buildpacks-python/releases/tag/v0.12.0

This seems to be happening because newer versions of pack with multi-arch support are detecting these buildpacks as multi-arch buildpacks, and thus tries to build a `"{os}-{arch}.cnb"` for each of the targets: https://github.com/buildpacks/pack/pull/2086/files#diff-f149889a3ad04f6ef0e49a7bc274d34be83c6e9ce07539c4ad4c65561fdc7bbaR184-R185

This PR forces `pack buildpack package` to use a `--target` argument, like `--target linux/amd64` which causes `pack` to skip a bunch of the multi-arch concerns (multi-arch concerns are already handled by this automation) like these suffixes.

[Example (dry) run with correct file names](https://github.com/heroku/buildpacks-nodejs/actions/runs/9769346128/job/26968688699)