### PR TITLE
Restore safe Docker publishing

### DIFF
--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -147,7 +147,7 @@ jobs:
 
   publish-docker:
     name: Publish → Docker - ${{ matrix.buildpack_id }}
-    needs: [compile]
+    needs: [ compile ]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -156,7 +156,7 @@ jobs:
     steps:
       # Composite buildpacks that depend on bash buildpacks (like
       # heroku/nodejs-function) refer to bash buildpacks by their source
-      # location rather than the packaged location. Other buildpacks don't
+      # location rather than the packaged location. Other buildpacks
       # don't need this step, so it's skipped where possible.
       - name: Checkout
         if: matrix.buildpack_type == 'composite'
@@ -186,7 +186,12 @@ jobs:
           username: ${{ secrets.docker_hub_user }}
           password: ${{ secrets.docker_hub_token }}
 
+      - name: Check if version is already on Docker Hub
+        id: check
+        run: echo "published_to_docker=$(docker manifest inspect "${{ matrix.stable_tag }}" &> /dev/null && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
+
       - name: Publish to temporary tags
+        if: steps.check.outputs.published_to_docker == 'false'
         env:
           TARGETS: ${{ toJSON(matrix.targets) }}
         run: |
@@ -222,7 +227,7 @@ jobs:
           fi
 
       - name: Promote temporary tags to stable tags
-        if: inputs.dry_run == false
+        if: inputs.dry_run == false && steps.check.outputs.published_to_docker == 'false'
         env:
           TARGETS: ${{ toJSON(matrix.targets) }}
         run: |
@@ -270,7 +275,7 @@ jobs:
 
   publish-github:
     name: Publish → GitHub Release
-    needs: [compile]
+    needs: [ compile ]
     runs-on: ${{ inputs.ip_allowlisted_runner }}
     steps:
       # Composite buildpacks that depend on bash buildpacks (like
@@ -332,7 +337,7 @@ jobs:
 
   publish-cnb-registry:
     name: Publish → CNB Registry - ${{ matrix.buildpack_id }}
-    needs: [compile, publish-docker]
+    needs: [ compile, publish-docker ]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -367,7 +372,7 @@ jobs:
 
   update-builder:
     name: Update Builder
-    needs: [compile, publish-docker, publish-cnb-registry, publish-github]
+    needs: [ compile, publish-docker, publish-cnb-registry, publish-github ]
     runs-on: ${{ inputs.ip_allowlisted_runner }}
     steps:
       - name: Get token for GH application (Linguist)

--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -147,7 +147,7 @@ jobs:
 
   publish-docker:
     name: Publish → Docker - ${{ matrix.buildpack_id }}
-    needs: [ compile ]
+    needs: [compile]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -275,7 +275,7 @@ jobs:
 
   publish-github:
     name: Publish → GitHub Release
-    needs: [ compile ]
+    needs: [compile]
     runs-on: ${{ inputs.ip_allowlisted_runner }}
     steps:
       # Composite buildpacks that depend on bash buildpacks (like
@@ -337,7 +337,7 @@ jobs:
 
   publish-cnb-registry:
     name: Publish → CNB Registry - ${{ matrix.buildpack_id }}
-    needs: [ compile, publish-docker ]
+    needs: [compile, publish-docker]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -372,7 +372,7 @@ jobs:
 
   update-builder:
     name: Update Builder
-    needs: [ compile, publish-docker, publish-cnb-registry, publish-github ]
+    needs: [compile, publish-docker, publish-cnb-registry, publish-github]
     runs-on: ${{ inputs.ip_allowlisted_runner }}
     steps:
       - name: Get token for GH application (Linguist)


### PR DESCRIPTION
This fix restores the safety of triggering the release automation on an existing release which was lost in the updates for publishing multi-arch Docker images in #194.

The buildpack matrix output can contain two variants of images to publish:

- A CNB with a single target. E.g.;

    ```json
    {
      "buildpack_id": "heroku/nodejs-function",
      "buildpack_version": "3.2.6",
      "buildpack_type": "composite",
      "buildpack_dir": "/home/runner/work/buildpacks-nodejs/buildpacks-nodejs/meta-buildpacks/nodejs-function",
      "targets": [
        {
          "os": "linux",
          "arch": "amd64",
          "rust_triple": "x86_64-unknown-linux-musl",
          "oci_target": "linux/amd64",
          "cnb_file": "heroku_nodejs-function.cnb",
          "stable_tag": "docker.io/heroku/buildpack-nodejs-function:3.2.6",
          "temporary_tag": "docker.io/heroku/buildpack-nodejs-function:_9781380433",
          "output_dir": "/home/runner/work/buildpacks-nodejs/buildpacks-nodejs/./packaged/x86_64-unknown-linux-musl/release/heroku_nodejs-function"
        }
      ],
      "image_repository": "docker.io/heroku/buildpack-nodejs-function",
      "stable_tag": "docker.io/heroku/buildpack-nodejs-function:3.2.6",
      "temporary_tag": "docker.io/heroku/buildpack-nodejs-function:_9781380433"
    }
    ```

- Or a CNB with multiple targets. E.g.;

    ```json
    {
      "buildpack_id": "heroku/nodejs-npm-install",
      "buildpack_version": "3.2.6",
      "buildpack_type": "libcnb",
      "buildpack_dir": "/home/runner/work/buildpacks-nodejs/buildpacks-nodejs/buildpacks/nodejs-npm-install",
      "targets": [
        {
          "os": "linux",
          "arch": "amd64",
          "rust_triple": "x86_64-unknown-linux-musl",
          "oci_target": "linux/amd64",
          "cnb_file": "heroku_nodejs-npm-install_linux-amd64.cnb",
          "stable_tag": "docker.io/heroku/buildpack-nodejs-npm-install:3.2.6_linux-amd64",
          "temporary_tag": "docker.io/heroku/buildpack-nodejs-npm-install:_9781380433_linux-amd64",
          "output_dir": "/home/runner/work/buildpacks-nodejs/buildpacks-nodejs/./packaged/x86_64-unknown-linux-musl/release/heroku_nodejs-npm-install"
        },
        {
          "os": "linux",
          "arch": "arm64",
          "rust_triple": "aarch64-unknown-linux-musl",
          "oci_target": "linux/arm64",
          "cnb_file": "heroku_nodejs-npm-install_linux-arm64.cnb",
          "stable_tag": "docker.io/heroku/buildpack-nodejs-npm-install:3.2.6_linux-arm64",
          "temporary_tag": "docker.io/heroku/buildpack-nodejs-npm-install:_9781380433_linux-arm64",
          "output_dir": "/home/runner/work/buildpacks-nodejs/buildpacks-nodejs/./packaged/aarch64-unknown-linux-musl/release/heroku_nodejs-npm-install"
        }
      ],
      "image_repository": "docker.io/heroku/buildpack-nodejs-npm-install",
      "stable_tag": "docker.io/heroku/buildpack-nodejs-npm-install:3.2.6",
      "temporary_tag": "docker.io/heroku/buildpack-nodejs-npm-install:_9781380433"
    }
    ```

When the automation runs successfully, either a single image or multiple images + a manifest list will have been published. Both the single image and manifest list are tagged with the value `matrix.stable_tag`. Therefore, if this tag exists, we shouldn't need to publish anything to Docker and we can skip that work.

Fixes #238