### PR TITLE
Update CI to Ubuntu 24.04 runner images

### DIFF
--- a/.github/workflows/_buildpacks-prepare-release.yml
+++ b/.github/workflows/_buildpacks-prepare-release.yml
@@ -31,7 +31,7 @@ on:
         description: The GitHub Actions runner to use to run jobs that require IP allow-list privileges
         type: string
         required: false
-        default: pub-hk-ubuntu-22.04-small
+        default: pub-hk-ubuntu-24.04-ip
       languages_cli_branch:
         description: The branch to install the Languages CLI from (FOR TESTING)
         type: string

--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -26,7 +26,7 @@ on:
         description: The GitHub Actions runner to use to run jobs that require IP allow-list privileges
         type: string
         required: false
-        default: pub-hk-ubuntu-22.04-small
+        default: pub-hk-ubuntu-24.04-ip
       languages_cli_branch:
         description: The branch to install the Languages CLI from (FOR TESTING)
         type: string
@@ -60,7 +60,7 @@ env:
 jobs:
   compile:
     name: Compile Buildpacks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       buildpacks: ${{ steps.generate-buildpack-matrix.outputs.buildpacks }}
       version: ${{ steps.generate-buildpack-matrix.outputs.version }}
@@ -148,7 +148,7 @@ jobs:
   publish-docker:
     name: Publish → Docker - ${{ matrix.buildpack_id }}
     needs: [compile]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -338,7 +338,7 @@ jobs:
   publish-cnb-registry:
     name: Publish → CNB Registry - ${{ matrix.buildpack_id }}
     needs: [compile, publish-docker]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/_classic-buildpack-prepare-release.yml
+++ b/.github/workflows/_classic-buildpack-prepare-release.yml
@@ -18,7 +18,7 @@ defaults:
 jobs:
   prepare-release:
     name: Prepare Release
-    runs-on: pub-hk-ubuntu-22.04-small
+    runs-on: pub-hk-ubuntu-24.04-ip
     steps:
       # We use our GitHub App's access token instead of GITHUB_TOKEN since otherwise other
       # workflows (such as CI) won't automatically run on any PRs opened by this workflow:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -40,7 +40,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   prepare:
     name: Release
-    runs-on: pub-hk-ubuntu-22.04-small
+    runs-on: pub-hk-ubuntu-24.04-ip
     steps:
       - name: Get token for GH application (Linguist)
         uses: actions/create-github-app-token@v1

--- a/README.md
+++ b/README.md
@@ -71,13 +71,13 @@ jobs:
 
 #### Inputs
 
-| Name                            | Description                                                                                                                                                                                             | Required | Default                     |
-|---------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|-----------------------------|
-| `app_id`                        | Application ID of GitHub application (e.g. the Linguist App)                                                                                                                                            | true     |                             |
-| `bump`                          | Which component of the version to increment (major, minor, or patch)                                                                                                                                    | true     |                             |
-| `declarations_starting_version` | Only needed if existing releases have been published but there is no matching release tag in Git. If this is the case, the first git tag that matches a version from your CHANGELOG should be supplied. | false    |                             |
-| `ip_allowlisted_runner`         | The GitHub Actions runner to use to run jobs that require IP allow-list privileges                                                                                                                      | false    | `pub-hk-ubuntu-22.04-small` |
-| `languages_cli_branch`          | The branch to install the Languages CLI from (FOR TESTING)                                                                                                                                              | false    | `main`                      |
+| Name                            | Description                                                                                                                                                                                             | Required | Default                  |
+|---------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|--------------------------|
+| `app_id`                        | Application ID of GitHub application (e.g. the Linguist App)                                                                                                                                            | true     |                          |
+| `bump`                          | Which component of the version to increment (major, minor, or patch)                                                                                                                                    | true     |                          |
+| `declarations_starting_version` | Only needed if existing releases have been published but there is no matching release tag in Git. If this is the case, the first git tag that matches a version from your CHANGELOG should be supplied. | false    |                          |
+| `ip_allowlisted_runner`         | The GitHub Actions runner to use to run jobs that require IP allow-list privileges                                                                                                                      | false    | `pub-hk-ubuntu-24.04-ip` |
+| `languages_cli_branch`          | The branch to install the Languages CLI from (FOR TESTING)                                                                                                                                              | false    | `main`                   |
 
 #### Secrets
 
@@ -132,12 +132,12 @@ jobs:
 
 #### Inputs
 
-| Name                    | Description                                                                                         | Required | Default                     |
-|-------------------------|-----------------------------------------------------------------------------------------------------|----------|-----------------------------|
-| `app_id`                | Application ID of GitHub application (e.g. the Linguist App)                                        | true     |                             |
-| `dry_run`               | Flag used for testing purposes to prevent actions that perform publishing operations from executing | false    | false                       |
-| `ip_allowlisted_runner` | The GitHub Actions runner to use to run jobs that require IP allow-list privileges                  | false    | `pub-hk-ubuntu-22.04-small` |
-| `languages_cli_branch`  | The branch to install the Languages CLI from (FOR TESTING)                                          | false    | `main`                      |
+| Name                    | Description                                                                                         | Required | Default                  |
+|-------------------------|-----------------------------------------------------------------------------------------------------|----------|--------------------------|
+| `app_id`                | Application ID of GitHub application (e.g. the Linguist App)                                        | true     |                          |
+| `dry_run`               | Flag used for testing purposes to prevent actions that perform publishing operations from executing | false    | false                    |
+| `ip_allowlisted_runner` | The GitHub Actions runner to use to run jobs that require IP allow-list privileges                  | false    | `pub-hk-ubuntu-24.04-ip` |
+| `languages_cli_branch`  | The branch to install the Languages CLI from (FOR TESTING)                                          | false    | `main`                   |
 
 #### Secrets
 


### PR DESCRIPTION
Now that Ubuntu 24.04 images are available on GitHub Actions, we can update from the Ubuntu 22.04 images.

See also:
https://github.com/actions/runner-images/issues/9848
https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
https://salesforce.quip.com/bu6UA0KImOxJ#temp:C:GZRd13d2ce2d455470495cbd34cf

GUS-W-16238120.