### PR TITLE
Arch specific dependencies

### DIFF
--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -132,6 +132,9 @@ jobs:
               echo "Packaging ${buildpack_dir}."
               triple=$(jq --exit-status -r '.rust_triple' <<< "${target}")
               cargo libcnb package --release --package-dir "${package_dir}" --target "${triple}"
+              os=$(jq --exit-status -r '.os' <<< "${target}")
+              arch=$(jq --exit-status -r '.arch' <<< "${target}")
+              sed -r -i "s/(docker:\/\/.+:[0-9.]+)/\0_${os}-${arch}/" "${package_dir}/package.toml"
             done
           done
 

--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -134,7 +134,7 @@ jobs:
               cargo libcnb package --release --package-dir "${package_dir}" --target "${triple}"
               os=$(jq --exit-status -r '.os' <<< "${target}")
               arch=$(jq --exit-status -r '.arch' <<< "${target}")
-              sed -r -i "s/(docker:\/\/.+:[0-9.]+)/\0_${os}-${arch}/" "${package_dir}/package.toml"
+              sed -r -i "s/(docker:\/\/.+:[0-9.]+)/\0_${os}-${arch}/" "${output_dir}/package.toml"
             done
           done
 


### PR DESCRIPTION
When running `pack buildpack package` with a buildpack that has a `docker` dependency on a multi-arch image index like this:

```
[dependencies]
uri = "docker://heroku/buildpack-release-phase:1.0.3"
```

Pack defers the image resolution to docker. This works fine when packaging a buildpack for the host platform, but breaks when packaging for another architecture. The default docker image store (which pack uses) is not able to properly handle cross platform images. The error manifests like this:

```
ERROR: packaging dependencies (uri='docker://heroku/buildpack-release-phase:1.0.3',image=''): extracting from registry 'docker://heroku/buildpack-release-phase:1.0.3': extracting buildpacks from 'heroku/buildpack-release-phase:1.0.3': could not find label 'io.buildpacks.buildpackage.metadata'
```

This PR does a basic regex substitution to append the appropriate platform suffix, so the package.toml references the docker tag for the appropriate platform like this:

```
[dependencies]
uri = "docker://heroku/buildpack-release-phase:1.0.3_linux-arm64"
```

or

```
[dependencies]
uri = "docker://heroku/buildpack-release-phase:1.0.3_linux-amd64"
```

An example passing workflow that did not without this change: https://github.com/heroku/buildpacks-frontend-web/actions/runs/12381045454/job/34558845731