### PR TITLE
Run `apt-get update` before installing cross-compile deps

### DIFF
--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -88,11 +88,11 @@ jobs:
         env:
           RUST_TRIPLES: ${{ steps.generate-buildpack-matrix.outputs.rust_triples }}
         run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends musl-tools
           for triple in $(jq --exit-status -r '.[]' <<< "${RUST_TRIPLES}"); do
             if [[ "$triple" == "aarch64-unknown-linux-musl" ]]; then
-              sudo apt-get install musl-tools gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libc6-dev-arm64-cross --no-install-recommends
-            elif [[ "$triple" == "x86_64-unknown-linux-musl" ]]; then
-              sudo apt-get install musl-tools --no-install-recommends
+              sudo apt-get install --no-install-recommends gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libc6-dev-arm64-cross
             fi
             rustup target add "$triple"
           done


### PR DESCRIPTION
This morning we started seeing CNB release jobs fail during the step that installs the cross-compile dependencies, due to a 404 Not Found from the APT mirror, eg:

```
 Get:26 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 g++-aarch64-linux-gnu amd64 4:13.2.0-7ubuntu1 [962 B]
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/b/binutils/binutils-aarch64-linux-gnu_2.42-4ubuntu2.3_amd64.deb  404  Not Found [IP: 40.81.13.82 80]
Fetched 56.3 MB in 30s (1886 kB/s)
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

(https://github.com/heroku/buildpacks-jvm/actions/runs/13588383287/job/37988366601)

After opening a support ticket with Canonical, they suggested we run `apt-get update`, which did resolve the issue.

Whilst GitHub Actions rebuild their runner images every two weeks (so in general the APT index in the image will be fairly recent), it seems that for some reason they pulled the old version of `inutils-aarch64-linux-gnu` immediately after it was most recently updated - therefore meaning an up to date APT repo index is needed otherwise installs will fail.

As such, I've added an explicit `apt-get update` now to avoid this. (I've also cleaned up the `apt-get` related steps slightly.)

Auditing our other repos, I see the CI jobs for our CNBs similarly don't use `apt-get update`, however, I think we can leave them as-is, since:
- They only have to install `musl-tools` (which wasn't affected) rather than all the cross-arch packages (which I suspect are less frequently used and maybe why they were pulled from the image sooner?).
- The CI jobs are more end-to-end time sensitive, and the `apt-get update` step can be slow.

GUS-W-17937217.