### PR TITLE
Allow configuring the PR reviewer for cnb-builder-images PRs

### DIFF
--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -22,6 +22,10 @@ on:
         type: boolean
         default: false
         description: Flag used for testing purposes to prevent actions that perform publishing operations from executing
+      reviewers:
+        description: A comma separated list of GitHub usernames from whom cnb-builder-images PR review will be requested, overriding the CODEOWNERS default of the Languages team.
+        type: string
+        required: false
       ip_allowlisted_runner:
         description: The GitHub Actions runner to use to run jobs that require IP allow-list privileges
         type: string
@@ -427,6 +431,7 @@ jobs:
             Update ${{ github.repository }} to v${{ needs.compile.outputs.version }}
 
             ${{ needs.compile.outputs.changelog }}
+          reviewers: ${{ inputs.reviewers }}
           path: ./cnb-builder-images
           branch: update/${{ github.repository }}
           delete-branch: true


### PR DESCRIPTION
Currently for CNB releases, the PR opened against `cnb-builder-images` doesn't have an explicit reviewer set by the automation, which means it uses that repo's `CODEOWNERS` default of requesting review from the whole Languages team.

Now, the workflow accepts an optional `reviewers` input, which can be used to select a specific person (eg the language owner) for review.

This will help reduce review-request-spam to other team members, and make it easier to see who each PR is waiting on in eg the Slack review reminders.

See:
https://github.com/peter-evans/create-pull-request?tab=readme-ov-file#action-inputs
https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputs

GUS-W-18011095. 