### PR TITLE
Reduce scopes granted to `GITHUB_TOKEN` in GitHub Actions workflows

### DIFF
--- a/.github/workflows/_buildpacks-prepare-release.yml
+++ b/.github/workflows/_buildpacks-prepare-release.yml
@@ -42,6 +42,9 @@ on:
         description: Private key of GitHub application (Linguist)
         required: true
 
+# Disable all GITHUB_TOKEN permissions, since the GitHub App token is used instead.
+permissions: {}
+
 defaults:
   run:
     # Setting an explicit bash shell ensures GitHub Actions enables pipefail mode too,

--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -50,6 +50,9 @@ on:
         required: true
         description: The token to login to Docker Hub with
 
+# Disable all GITHUB_TOKEN permissions, since the GitHub App token is used instead.
+permissions: {}
+
 defaults:
   run:
     # Setting an explicit bash shell ensures GitHub Actions enables pipefail mode too,
@@ -254,6 +257,9 @@ jobs:
         if: always()
         env:
           TARGETS: ${{ toJSON(matrix.targets) }}
+        # TODO: Consider using secret masking for the generated token here, or preferably
+        # switching to an approach that doesn't involve manually crafted curl requests.
+        # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#masking-a-value-in-a-log
         run: |
           dockerhub_token=$(curl -sS -f --retry 3 --retry-connrefused --connect-timeout 5 --max-time 30 -H "Content-Type: application/json" -X POST -d "{\"username\": \"${{ secrets.docker_hub_user }}\", \"password\": \"${{ secrets.docker_hub_token }}\"}" https://hub.docker.com/v2/users/login/ | jq --exit-status -r .token)
           namespace=$(cut -d "/" -f2 <<< "${{ matrix.image_repository }}")

--- a/.github/workflows/_classic-buildpack-prepare-release.yml
+++ b/.github/workflows/_classic-buildpack-prepare-release.yml
@@ -8,6 +8,9 @@ on:
         type: string
         required: false
 
+# Disable all GITHUB_TOKEN permissions, since the GitHub App token is used instead.
+permissions: {}
+
 defaults:
   run:
     # Setting an explicit bash shell ensures GitHub Actions enables pipefail mode too,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 defaults:
   run:
     # Setting an explicit bash shell ensures GitHub Actions enables pipefail mode too,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ on:
           - minor
           - patch
 
+# Disable all GITHUB_TOKEN permissions, since the GitHub App token is used instead.
+permissions: {}
+
 defaults:
   run:
     # Setting an explicit bash shell ensures GitHub Actions enables pipefail mode too,

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ on:
           - minor
           - patch
 
+# Disable all GITHUB_TOKEN permissions, since the GitHub App token is used instead.
+permissions: {}
+
 jobs:
   prepare-release:
     uses: heroku/languages-github-actions/.github/workflows/_buildpacks-prepare-release.yml@latest
@@ -115,6 +118,9 @@ name: Release Buildpacks
 
 on:
   workflow_dispatch:
+
+# Disable all GITHUB_TOKEN permissions, since the GitHub App token is used instead.
+permissions: {}
 
 jobs:
   release:


### PR DESCRIPTION
As part of security-hardening our GHA workflows, this reduces the permissions granted to the automatically set `GITHUB_TOKEN` env var in GitHub Actions workflows to no more than what is required by that workflow.

See:
https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication

GUS-W-18053749.