### PR TITLE
Add missing `--locked` to Cargo commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,13 @@ jobs:
         uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
 
       - name: Clippy
-        run: cargo clippy --all-targets --all-features -- --deny warnings
+        run: cargo clippy --all-targets --all-features --locked -- --deny warnings
 
       - name: rustfmt
         run: cargo fmt -- --check
 
       - name: Check docs
-        run: RUSTDOCFLAGS="-D warnings" cargo doc --all-features --document-private-items --no-deps
+        run: RUSTDOCFLAGS="-D warnings" cargo doc --all-features --document-private-items --no-deps --locked
 
   test:
     name: Test
@@ -55,4 +55,4 @@ jobs:
         uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
 
       - name: Test
-        run: cargo test --all-features
+        run: cargo test --all-features --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
         uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
 
       - name: Install cargo-bump
-        run: cargo install cargo-bump
+        run: cargo install --locked cargo-bump
 
       - name: Get previous release version
         id: previous-version
@@ -72,13 +72,13 @@ jobs:
           cargo bump ${{ inputs.bump }}
 
       - name: Build
-        run: cargo build --release
+        run: cargo build --release --locked
 
       - name: Get release metadata
         id: metadata
         run: |
-          echo "name=$(cargo metadata --format-version=1 --no-deps | jq --exit-status -r '.packages[-1].targets[-1].name')" >> $GITHUB_OUTPUT
-          echo "version=$(cargo metadata --format-version=1 --no-deps | jq --exit-status -r '.packages[-1].version')" >> $GITHUB_OUTPUT
+          echo "name=$(cargo metadata --format-version=1 --no-deps --locked | jq --exit-status -r '.packages[-1].targets[-1].name')" >> $GITHUB_OUTPUT
+          echo "version=$(cargo metadata --format-version=1 --no-deps --locked | jq --exit-status -r '.packages[-1].version')" >> $GITHUB_OUTPUT
 
       - name: Package binary
         id: package-binary


### PR DESCRIPTION
The Cargo `--locked` argument ensures that Cargo will fail with an error if `Cargo.lock` is out of sync with `Cargo.toml`, rather than the lockfile being silently updated.

As such, in CI we should always be using `--locked` for projects that have committed their lockfile to Git (which should be the case for most projects other than those that are libraries).

After seeing that `cnb-otel-collector` didn't use `--locked` in all cases, I audited all of our Rust repos and found others missing `--locked` too.

GUS-W-18062544.