### PR TITLE
Remove the `--locked` usage from the actions release step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,9 @@ jobs:
           cargo bump ${{ inputs.bump }}
 
       - name: Build
-        run: cargo build --release --locked
+        # Not using --locked since the lockfile will need updating for the version bump. The CI
+        # workflows for this repo will ensure the rest of the lockfile is up to date.
+        run: cargo build --release
 
       - name: Get release metadata
         id: metadata


### PR DESCRIPTION
Since this step, unlike all the others, actually has to update the lockfile for the version bump that's just occurred.

Fixes:
https://github.com/heroku/languages-github-actions/actions/runs/14218865177/job/39841765156#step:10:9

Follow-up to #293. 