### PR TITLE
Stop updating CNB versions in `heroku/builder:20`

### DIFF
--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -424,7 +424,7 @@ jobs:
         # image to exist in order to calculate a digest with `crane`. Adding the check here
         # means no files will be modified and so no PR will be created later.
         if: inputs.dry_run == false
-        run: actions update-builder --repository-path ./buildpacks --builder-repository-path ./cnb-builder-images --builders builder-20,builder-22,builder-24,salesforce-functions
+        run: actions update-builder --repository-path ./buildpacks --builder-repository-path ./cnb-builder-images --builders builder-22,builder-24,salesforce-functions
 
       - name: Create Pull Request
         id: pr


### PR DESCRIPTION
Since our CNBs have started to drop support for Ubuntu 20.04 / Heroku-20 (since they have reached end-of-life), eg:

- https://github.com/heroku/buildpacks-python/pull/358
- https://github.com/heroku/buildpacks-ruby/pull/422

...and so we don't want the release automation to update to these new versions in `heroku/builder:20`.

GUS-W-14706143.