### PR TITLE
Remove salesforce-functions builder from builders list

### DIFF
--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -424,7 +424,7 @@ jobs:
         # image to exist in order to calculate a digest with `crane`. Adding the check here
         # means no files will be modified and so no PR will be created later.
         if: inputs.dry_run == false
-        run: actions update-builder --repository-path ./buildpacks --builder-repository-path ./cnb-builder-images --builders builder-22,builder-24,salesforce-functions
+        run: actions update-builder --repository-path ./buildpacks --builder-repository-path ./cnb-builder-images --builders builder-22,builder-24
 
       - name: Create Pull Request
         id: pr


### PR DESCRIPTION
Since the builder no longer exists on CNB builder images `main` after:
https://github.com/heroku/cnb-builder-images/pull/782

GUS-W-19325110.