### PR TITLE
Fix token passing after `softprops/action-gh-release` change

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,9 +126,8 @@ jobs:
 
       - name: Create release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
-        env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           target_commitish: ${{ steps.release-tag.outputs.sha }}
           tag_name: v${{ steps.metadata.outputs.version }}
           files: ${{ steps.package-binary.outputs.path }}


### PR DESCRIPTION
The `softprops/action-gh-release` action seems to now prefer `github.token` over the `GITHUB_TOKEN` env var, if an explicit input token hasn't been provided via the `with`  `token` field.

This caused a failure on publish:

```
 👩‍🏭 Creating new GitHub release for tag v1.6.1 using commit "48773f297dbae514171a4f3d02a22e7eb1396451"...
⚠️ GitHub release failed with status: 403
{"message":"Resource not accessible by integration","documentation_url":"https://docs.github.com/rest/releases/releases#create-a-release","status":"403"}
Skip retry — your GitHub token/PAT does not have the required permission to create a release
⚠️ Unexpected error fetching GitHub release for tag refs/heads/main: HttpError: Resource not accessible by integration - https://docs.github.com/rest/releases/releases#create-a-release
```

https://github.com/heroku/languages-github-actions/actions/runs/23859408410/job/69561642885#step:17:20

This switches to using the intended `token` field:
https://github.com/softprops/action-gh-release#inputs

GUS-W-21858821.