### PR TITLE
Document auto-triggering release on prepare-release PR merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.merged == true &&
+       github.event.pull_request.head.repo.full_name == github.repository &&
        github.event.pull_request.head.ref == 'prepare-release')
     uses: heroku/languages-github-actions/.github/workflows/_buildpacks-release.yml@latest
     with:

--- a/README.md
+++ b/README.md
@@ -146,7 +146,8 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.merged == true &&
        github.event.pull_request.head.repo.full_name == github.repository &&
-       github.event.pull_request.head.ref == 'prepare-release')
+       github.event.pull_request.head.ref == 'prepare-release' &&
+       github.event.pull_request.user.login == 'heroku-linguist[bot]')
     uses: heroku/languages-github-actions/.github/workflows/_buildpacks-release.yml@latest
     with:
       app_id: ${{ vars.GH_APP_ID }}

--- a/README.md
+++ b/README.md
@@ -124,6 +124,13 @@ You can pin to:
 name: Release Buildpacks
 
 on:
+  # Auto-trigger when the "Prepare release" PR (created by the
+  # _buildpacks-prepare-release.yml workflow) is merged.
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
   workflow_dispatch:
 
 # Disable all GITHUB_TOKEN permissions, since the GitHub App token is used instead.
@@ -132,6 +139,13 @@ permissions: {}
 jobs:
   release:
     name: Release
+    # On `pull_request`, only run for the merged auto-generated
+    # "Prepare release" PR (branch name set by
+    # _buildpacks-prepare-release.yml). Manual dispatches always run.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+       github.event.pull_request.head.ref == 'prepare-release')
     uses: heroku/languages-github-actions/.github/workflows/_buildpacks-release.yml@latest
     with:
       app_id: ${{ vars.GH_APP_ID }}


### PR DESCRIPTION
Adds `on: pull_request: [closed]` and an `if:` gate to the documented release workflow example, so consumers can opt into having the release workflow auto-trigger when the auto-generated "Prepare release" PR is merged. Manual `workflow_dispatch` is preserved for re-runs and dry-run testing.

README-only change; the shared `_buildpacks-release.yml` is unchanged. The gating logic lives in the consumer alongside the trigger, so each consumer's release config remains self-documenting.

Also see https://github.com/heroku/buildpacks-dotnet/pull/425

Resolves #96.

GUS-W-13871118