### PR TITLE
Comment release progress on the prepare-release PR

### DIFF
--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -386,7 +386,7 @@ jobs:
           fail_on_unmatched_files: true
 
       - name: Notify GitHub release published on prepare PR
-        if: github.event_name == 'pull_request' && inputs.dry_run == false
+        if: github.event_name == 'pull_request' && inputs.dry_run == false && steps.check.outputs.already_published_to_github == 'false'
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -73,6 +73,24 @@ jobs:
       version: ${{ steps.generate-buildpack-matrix.outputs.version }}
       changelog: ${{ steps.generate-changelog.outputs.changelog }}
     steps:
+      - name: Get token for prepare PR comment
+        if: github.event_name == 'pull_request'
+        uses: actions/create-github-app-token@v3
+        id: comment-token
+        with:
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.app_private_key }}
+
+      - name: Notify release started on prepare PR
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ steps.comment-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh pr comment "$PR_NUMBER" --body "Release workflow started: $RUN_URL"
+
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -367,6 +385,16 @@ jobs:
           files: "*.cnb"
           fail_on_unmatched_files: true
 
+      - name: Notify GitHub release published on prepare PR
+        if: github.event_name == 'pull_request' && inputs.dry_run == false
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RELEASE_URL: ${{ github.server_url }}/${{ github.repository }}/releases/tag/v${{ needs.compile.outputs.version }}
+        run: |
+          gh pr comment "$PR_NUMBER" --body "GitHub release published: $RELEASE_URL"
+
   publish-cnb-registry:
     name: Publish → CNB Registry - ${{ matrix.buildpack_id }}
     needs: [compile, publish-docker]
@@ -469,3 +497,21 @@ jobs:
         run: gh pr merge --auto --squash --repo heroku/cnb-builder-images "${{ steps.pr.outputs.pull-request-number }}"
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+
+      - name: Get token for prepare PR comment
+        if: github.event_name == 'pull_request' && inputs.dry_run == false && steps.pr.outputs.pull-request-operation == 'created'
+        uses: actions/create-github-app-token@v3
+        id: comment-token
+        with:
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.app_private_key }}
+
+      - name: Notify builder PR opened on prepare PR
+        if: github.event_name == 'pull_request' && inputs.dry_run == false && steps.pr.outputs.pull-request-operation == 'created'
+        env:
+          GH_TOKEN: ${{ steps.comment-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BUILDER_PR_URL: ${{ steps.pr.outputs.pull-request-url }}
+        run: |
+          gh pr comment "$PR_NUMBER" --body "Builder PR opened: $BUILDER_PR_URL — review and merge to complete the release."

--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -385,16 +385,6 @@ jobs:
           files: "*.cnb"
           fail_on_unmatched_files: true
 
-      - name: Notify GitHub release published on prepare PR
-        if: github.event_name == 'pull_request' && inputs.dry_run == false && steps.check.outputs.already_published_to_github == 'false'
-        env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-          GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          RELEASE_URL: ${{ github.server_url }}/${{ github.repository }}/releases/tag/v${{ needs.compile.outputs.version }}
-        run: |
-          gh pr comment "$PR_NUMBER" --body "GitHub release published: $RELEASE_URL"
-
   publish-cnb-registry:
     name: Publish → CNB Registry - ${{ matrix.buildpack_id }}
     needs: [compile, publish-docker]
@@ -515,3 +505,25 @@ jobs:
           BUILDER_PR_URL: ${{ steps.pr.outputs.pull-request-url }}
         run: |
           gh pr comment "$PR_NUMBER" --body "Builder PR opened: $BUILDER_PR_URL — review and merge to complete the release."
+
+  notify-failure:
+    name: Notify Release Failure
+    needs: [compile, publish-docker, publish-cnb-registry, publish-github, update-builder]
+    if: failure() && github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Get token for prepare PR comment
+        uses: actions/create-github-app-token@v3
+        id: comment-token
+        with:
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.app_private_key }}
+
+      - name: Notify release failure on prepare PR
+        env:
+          GH_TOKEN: ${{ steps.comment-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh pr comment "$PR_NUMBER" --body "Release workflow finished with failures — see the workflow run at $RUN_URL"


### PR DESCRIPTION
When the release workflow runs from a prepare-release PR merge (the auto-trigger path enabled by #358), post status comments back to that PR. Two on the happy path, one on failure:

* When the workflow starts (links to the run)
* When the `cnb-builder-images` PR is opened (links to that PR)
* When any job fails (links to the workflow run)

The aim is to give the team enough signal to act on what the auto-trigger surfaces: reassurance that a release started, a follow-up handle for the builder PR, and visibility when something goes wrong. Things that help folks outside the team track release status — Docker Hub tags, CNB registry entry, post-publish state — feel better addressed by enriching the GitHub release description in a follow-up.

Notifications are skipped on `workflow_dispatch` and dry runs, so behavior for manual / testing invocations is unchanged.

A fourth notification (\"builder PR merged → release complete\") was scoped out — it requires changes in `heroku/cnb-builder-images` and is better tracked separately.

Resolves #113.

GUS-W-13955895.