### PR TITLE
Trim unnecessary dependencies from update-builder job

### DIFF
--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -427,7 +427,12 @@ jobs:
 
   update-builder:
     name: Update Builder
-    needs: [compile, publish-docker, publish-cnb-registry, publish-github]
+    # `update-builder` only needs the published Docker Hub image (read via
+    # `crane digest`) plus `compile` outputs. Keeping it independent of
+    # `publish-cnb-registry` and `publish-github` lets the builder PR open
+    # in parallel with those jobs and means CNB-registry downtime no
+    # longer blocks builder updates.
+    needs: [compile, publish-docker]
     runs-on: ${{ inputs.ip_allowlisted_runner }}
     steps:
       - name: Get token for GH application (Linguist)


### PR DESCRIPTION
`update-builder` only consumes the published Docker Hub image digest (read via `crane digest`) plus `compile` outputs — it has no functional dependency on `publish-cnb-registry` or `publish-github`. The current over-specified `needs:` list serializes the workflow unnecessarily and couples the cnb-builder-images PR to CNB registry availability; when `registry.buildpacks.io` is degraded, builder updates are blocked for no good reason.

Trims `needs:` to `[compile, publish-docker]` so the builder PR can open in parallel with `publish-cnb-registry` and `publish-github`. Speeds up end-to-end release time and decouples builder updates from CNB registry uptime.

Issue #117 noted this should wait until per-step failure signal exists, since previously "the builder PR never opened" was the only indication something went wrong. That prerequisite is met by #360, which posts comments to the prepare PR for each release step.

Resolves #117.

GUS-W-13956414