### PR TITLE
Run notification jobs on IP-allowlisted runner

### DIFF
--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -65,16 +65,14 @@ env:
   PACKAGE_DIR: ./packaged
 
 jobs:
-  compile:
-    name: Compile Buildpacks
-    runs-on: ubuntu-24.04
-    outputs:
-      buildpacks: ${{ steps.generate-buildpack-matrix.outputs.buildpacks }}
-      version: ${{ steps.generate-buildpack-matrix.outputs.version }}
-      changelog: ${{ steps.generate-changelog.outputs.changelog }}
+  notify-start:
+    name: Notify Release Started
+    if: github.event_name == 'pull_request'
+    # Runs on the IP-allowlisted runner because the GitHub App token mint hits
+    # the heroku org's IP allow list, which GitHub-hosted runners aren't on.
+    runs-on: ${{ inputs.ip_allowlisted_runner }}
     steps:
       - name: Get token for prepare PR comment
-        if: github.event_name == 'pull_request'
         uses: actions/create-github-app-token@v3
         id: comment-token
         with:
@@ -82,7 +80,6 @@ jobs:
           private-key: ${{ secrets.app_private_key }}
 
       - name: Notify release started on prepare PR
-        if: github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ steps.comment-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
@@ -91,6 +88,14 @@ jobs:
         run: |
           gh pr comment "$PR_NUMBER" --body "Release workflow started: $RUN_URL"
 
+  compile:
+    name: Compile Buildpacks
+    runs-on: ubuntu-24.04
+    outputs:
+      buildpacks: ${{ steps.generate-buildpack-matrix.outputs.buildpacks }}
+      version: ${{ steps.generate-buildpack-matrix.outputs.version }}
+      changelog: ${{ steps.generate-changelog.outputs.changelog }}
+    steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -510,7 +515,9 @@ jobs:
     name: Notify Release Failure
     needs: [compile, publish-docker, publish-cnb-registry, publish-github, update-builder]
     if: failure() && github.event_name == 'pull_request'
-    runs-on: ubuntu-24.04
+    # Runs on the IP-allowlisted runner because the GitHub App token mint hits
+    # the heroku org's IP allow list, which GitHub-hosted runners aren't on.
+    runs-on: ${{ inputs.ip_allowlisted_runner }}
     steps:
       - name: Get token for prepare PR comment
         uses: actions/create-github-app-token@v3


### PR DESCRIPTION
The start and failure notification jobs introduced in #360 mint a GitHub App token, which the `heroku` org's IP allow list rejects from GitHub-hosted runners. The first end-to-end release using the auto-trigger (https://github.com/heroku/buildpacks-dotnet/actions/runs/26034642220) hit this in both jobs and wedged v1.0.9.

* Extract the start notification from `compile` into its own `notify-start` job on `${{ inputs.ip_allowlisted_runner }}`. Keeps `compile` on the cheaper GitHub-hosted runner; the notification runs in parallel without blocking the critical path.
* Switch `notify-failure` to the same allowlisted runner.

The "Builder PR opened" notification is unaffected since it already runs inside `update-builder`, which uses the allowlisted runner.

GUS-W-22542808.