### PR TITLE
Drop "review and merge" call-to-action from builder PR comment

### DIFF
--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -526,7 +526,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           BUILDER_PR_URL: ${{ steps.pr.outputs.pull-request-url }}
         run: |
-          gh pr comment "$PR_NUMBER" --body "Builder PR opened: $BUILDER_PR_URL — review and merge to complete the release."
+          gh pr comment "$PR_NUMBER" --body "Builder PR opened: $BUILDER_PR_URL"
 
   notify-failure:
     name: Notify Release Failure


### PR DESCRIPTION
cnb-builder-images PRs are now auto-approved and auto-merged once CI passes (heroku/cnb-builder-images#979). The comment continues to surface the builder PR URL as a status signal.

Intentionally not mentioning auto-approve in the comment text itself — that part of the flow may change, and a bare URL ages better than a description of the current behavior.

GUS-W-22608943.