### PR TITLE
Allow classic buildpack publish to trigger on pull_request

### DIFF
--- a/.github/workflows/_classic-buildpack-publish.yml
+++ b/.github/workflows/_classic-buildpack-publish.yml
@@ -38,11 +38,13 @@ jobs:
     # ref. Privilege escalation is bounded by the registry's OIDC trust policy (which pins
     # repo + workflow path) — this guard is a convenience, not the security boundary.
     #
-    # The event_name allow-list keeps `pull_request_target` and `workflow_run` callers out:
-    # those run with elevated tokens in unusual ref contexts and are not legitimate triggers
-    # for a release publish.
+    # The legitimate triggers are `workflow_dispatch` (manual / QA) and `pull_request` (the
+    # merged "Prepare release" PR — on which GitHub sets github.ref to the base branch and
+    # github.sha to the merge commit, so the default-branch guard below still holds). The
+    # allow-list keeps `pull_request_target` and `workflow_run` callers out: those run with
+    # elevated tokens in unusual ref contexts and are not legitimate triggers for a publish.
     if: |
-      contains(fromJSON('["push","workflow_dispatch"]'), github.event_name)
+      contains(fromJSON('["workflow_dispatch","pull_request"]'), github.event_name)
       && (inputs.qa || github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
     runs-on: pub-hk-ubuntu-24.04-ip
     # Single source of truth for the qa-vs-production routing — every step that needs the

--- a/.github/workflows/_classic-buildpack-publish.yml
+++ b/.github/workflows/_classic-buildpack-publish.yml
@@ -43,8 +43,17 @@ jobs:
     # github.sha to the merge commit, so the default-branch guard below still holds). The
     # allow-list keeps `pull_request_target` and `workflow_run` callers out: those run with
     # elevated tokens in unusual ref contexts and are not legitimate triggers for a publish.
+    #
+    # The `merged == true` check is the one caller precondition we enforce here rather than
+    # leaving to the caller: an unmerged `pull_request` event (opened/synchronize/closed-
+    # without-merge) does NOT point github.ref/github.sha at a merge commit on the default
+    # branch, so the assumption the rest of this workflow relies on would not hold. We
+    # intentionally do NOT mirror the caller's other gates (head.ref == release branch,
+    # bot author) — those are caller-specific routing concerns (which PR is *the* release
+    # PR), whereas "this is a real merge" is a universal precondition for any publish.
     if: |
       contains(fromJSON('["workflow_dispatch","pull_request"]'), github.event_name)
+      && (github.event_name != 'pull_request' || github.event.pull_request.merged == true)
       && (inputs.qa || github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
     runs-on: pub-hk-ubuntu-24.04-ip
     # Single source of truth for the qa-vs-production routing — every step that needs the


### PR DESCRIPTION
## Problem

The reusable `_classic-buildpack-publish.yml` workflow gated its `publish` job on:

```yaml
contains(fromJSON('["push","workflow_dispatch"]'), github.event_name)
```

But the caller (`heroku-buildpack-nodejs/release.yml`) auto-triggers the publish from the **merged "Prepare release" PR** via a `pull_request: closed` event. `pull_request` was not in the allow-list, so the job **silently skipped with zero steps** — the v351 release ([run 26904885080](https://github.com/heroku/heroku-buildpack-nodejs/actions/runs/26904885080)) did not auto-publish.

The run log confirms it: the caller's own guard evaluated `true`, but `_classic-buildpack-publish.yml`'s job guard evaluated `false` on `contains(['push','workflow_dispatch'], 'pull_request')`.

This matches the CNB reusable workflow (`_buildpacks-release.yml`), which has no such event gate and publishes fine from the same `pull_request: closed` trigger.

## Fix

Swap `push` for `pull_request` in the event allow-list.

- **Why dropping `push` is safe:** no caller invokes this reusable workflow from a `push` event — the entry points are the merged prepare-release PR (`pull_request`) and manual/QA runs (`workflow_dispatch`).
- **Why no other change is needed:** on a PR that closes *as merged*, GitHub sets `github.ref` to the base branch (`refs/heads/main`) and `github.sha` to the merge commit on that branch. So the existing default-branch guard (`github.ref == refs/heads/main`) still holds, and a plain checkout lands on the merge commit — meaning `git tag`, the pre-flight `tag_sha == GITHUB_SHA` check, and the audit log all stay correct.
- The allow-list is retained as defense-in-depth, still excluding `pull_request_target` and `workflow_run`.

The comment above the guard is updated to reflect that `pull_request` is now the primary production trigger.

## Merged-PR guard (defense-in-depth)

Per review feedback, the guard also enforces `merged == true` for `pull_request` events:

```yaml
&& (github.event_name != 'pull_request' || github.event.pull_request.merged == true)
```

The Node.js caller already gates on `merged`/release-branch/bot-author, so this changes nothing for the current caller. But it makes the `github.ref`/`github.sha` reasoning above hold *at the reusable-workflow boundary* rather than depending on the caller: only a `pull_request` event that **closed as merged** points `github.ref` at the default branch and `github.sha` at a merge commit. An unmerged PR event (opened/synchronize/closed-without-merge) does not, so it must not publish.

I intentionally did **not** mirror the caller's other gates (release branch name, bot author): those are caller-specific *routing* concerns — "which PR is *the* release PR" — whereas "this is a real merge" is a universal precondition for any publish. The expression is written as `event != 'pull_request' || merged` (rather than `&& merged`) so manual `workflow_dispatch` runs, which have no `pull_request` object in the payload, are unaffected.

