### PR TITLE
Add Honeycomb release markers to classic buildpack publish

### DIFF
--- a/.github/workflows/_classic-buildpack-publish.yml
+++ b/.github/workflows/_classic-buildpack-publish.yml
@@ -25,6 +25,12 @@ on:
           Slack Workflow Builder webhook URL for #heroku-languages-ops. A message is posted
           here if a production publish fails.
         required: true
+      honeycomb_api_key:
+        description: >-
+          Honeycomb env API key with the 'create markers' scope. When set, a release
+          marker is posted to the `builds` dataset on a successful production publish.
+          Omit to disable (no-op for callers that don't opt in).
+        required: false
 
 # Full set of permissions the CALLING workflow must grant — a reusable workflow's GITHUB_TOKEN
 # is capped by what the caller provides. Each job below narrows to only what it needs via its

--- a/.github/workflows/_classic-buildpack-publish.yml
+++ b/.github/workflows/_classic-buildpack-publish.yml
@@ -758,6 +758,39 @@ jobs:
             exit 1
           fi
 
+      - name: Post Honeycomb release marker
+        # No-op when the secret is absent (other teams) or in QA mode. Secrets can't be
+        # referenced in `if:`, so the key is mirrored to env and tested there.
+        if: env.HONEYCOMB_API_KEY != '' && env.MODE == 'production'
+        env:
+          HONEYCOMB_API_KEY: ${{ secrets.honeycomb_api_key }}
+          HONEYCOMB_DATASET: builds          # shared dataset for all classic buildpacks
+          BUILDPACK_ID: ${{ inputs.buildpack_id }}
+          TAG: ${{ steps.tag.outputs.name }}
+        run: |
+          api="https://api.honeycomb.io/1/markers/${HONEYCOMB_DATASET}"
+          url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${TAG}"
+          msg="${BUILDPACK_ID} ${TAG}"
+          body=$(jq -n --arg msg "$msg" --arg url "$url" '{message: $msg, type: "deploy", url: $url}')
+          auth=(-H "X-Honeycomb-Team: ${HONEYCOMB_API_KEY}" -H "Content-Type: application/json")
+
+          # Dedup on the release URL: stable identity for this release. A re-run of an idempotent
+          # publish updates the existing marker rather than stacking a duplicate line on the board.
+          # Every path below warns on failure and never exits non-zero — a Honeycomb outage must
+          # not fail an already-successful publish.
+          existing=$(curl -sS --retry 3 --retry-all-errors --max-time 30 "${auth[@]}" "${api}" \
+            | jq -r --arg url "$url" 'map(select(.url == $url)) | first | .id // empty' 2>/dev/null) || existing=""
+
+          if [[ -n "$existing" ]]; then
+            curl -sS --retry 3 --retry-all-errors --max-time 30 -X PUT "${api}/${existing}" "${auth[@]}" -d "${body}" \
+              >/dev/null && echo "Updated existing release marker (${existing})" \
+              || echo "::warning::Failed to update Honeycomb release marker (publish succeeded regardless)"
+          else
+            curl -sS --retry 3 --retry-all-errors --max-time 30 -X POST "${api}" "${auth[@]}" -d "${body}" \
+              >/dev/null && echo "Created release marker for ${TAG}" \
+              || echo "::warning::Failed to create Honeycomb release marker (publish succeeded regardless)"
+          fi
+
   notify-failure:
     name: Notify Release Failure
     needs: [publish]

--- a/.github/workflows/_classic-buildpack-publish.yml
+++ b/.github/workflows/_classic-buildpack-publish.yml
@@ -775,18 +775,17 @@ jobs:
           auth=(-H "X-Honeycomb-Team: ${HONEYCOMB_API_KEY}" -H "Content-Type: application/json")
 
           # Dedup on the release URL: stable identity for this release. A re-run of an idempotent
-          # publish updates the existing marker rather than stacking a duplicate line on the board.
-          # Every path below warns on failure and never exits non-zero — a Honeycomb outage must
-          # not fail an already-successful publish.
-          existing=$(curl -sS --retry 3 --retry-all-errors --max-time 30 "${auth[@]}" "${api}" \
-            | jq -r --arg url "$url" 'map(select(.url == $url)) | first | .id // empty' 2>/dev/null) || existing=""
+          # publish finds the existing marker and skips, rather than stacking a duplicate line on
+          # the board. The marker content is fully derived from the tag, so there's nothing to
+          # update. This warns on failure and never exits non-zero — a Honeycomb outage must not
+          # fail an already-successful publish.
+          existing=$(curl -sS --fail --connect-timeout 10 --retry 3 --retry-all-errors --max-time 30 "${auth[@]}" "${api}" \
+            | jq -r --arg url "$url" 'map(select(.url == $url)) | first | .id // empty') || existing=""
 
           if [[ -n "$existing" ]]; then
-            curl -sS --retry 3 --retry-all-errors --max-time 30 -X PUT "${api}/${existing}" "${auth[@]}" -d "${body}" \
-              >/dev/null && echo "Updated existing release marker (${existing})" \
-              || echo "::warning::Failed to update Honeycomb release marker (publish succeeded regardless)"
+            echo "Release marker already exists (${existing}) — skipping"
           else
-            curl -sS --retry 3 --retry-all-errors --max-time 30 -X POST "${api}" "${auth[@]}" -d "${body}" \
+            curl -sS --fail --connect-timeout 10 --retry 3 --retry-all-errors --max-time 30 -X POST "${api}" "${auth[@]}" -d "${body}" \
               >/dev/null && echo "Created release marker for ${TAG}" \
               || echo "::warning::Failed to create Honeycomb release marker (publish succeeded regardless)"
           fi

--- a/.github/workflows/_classic-buildpack-publish.yml
+++ b/.github/workflows/_classic-buildpack-publish.yml
@@ -771,24 +771,31 @@ jobs:
           api="https://api.honeycomb.io/1/markers/${HONEYCOMB_DATASET}"
           url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${TAG}"
           msg="${BUILDPACK_ID} ${TAG}"
-          body=$(jq -n --arg msg "$msg" --arg url "$url" '{message: $msg, type: "deploy", url: $url}')
-          auth=(-H "X-Honeycomb-Team: ${HONEYCOMB_API_KEY}" -H "Content-Type: application/json")
+          # Anchor the marker to the release commit time, not "now": this step may run delayed
+          # after a re-trigger, and the commit timestamp is stable across re-runs. The repo is
+          # checked out at the commit being published (fetch-depth: 0), so HEAD is that commit.
+          start_time=$(git log -1 --format=%ct)
+          curl=(curl -sS --fail --connect-timeout 10 --retry 3 --retry-all-errors --max-time 30
+            -H "X-Honeycomb-Team: ${HONEYCOMB_API_KEY}" -H "Content-Type: application/json")
 
           # Dedup on the release URL: stable identity for this release. A re-run of an idempotent
           # publish finds the existing marker and skips, rather than stacking a duplicate line on
           # the board. The marker content is fully derived from the tag, so there's nothing to
-          # update. This warns on failure and never exits non-zero — a Honeycomb outage must not
-          # fail an already-successful publish.
-          existing=$(curl -sS --fail --connect-timeout 10 --retry 3 --retry-all-errors --max-time 30 "${auth[@]}" "${api}" \
-            | jq -r --arg url "$url" 'map(select(.url == $url)) | first | .id // empty') || existing=""
+          # update. This step is the last in the workflow and runs after the release has already
+          # published, so letting it fail red on a Honeycomb error surfaces the problem
+          # (retry/bug) without blocking the already-successful release.
+          existing=$("${curl[@]}" "${api}" \
+            | jq -r --arg url "$url" 'map(select(.url == $url)) | first | .id // empty')
 
           if [[ -n "$existing" ]]; then
             echo "Release marker already exists (${existing}) — skipping"
-          else
-            curl -sS --fail --connect-timeout 10 --retry 3 --retry-all-errors --max-time 30 -X POST "${api}" "${auth[@]}" -d "${body}" \
-              >/dev/null && echo "Created release marker for ${TAG}" \
-              || echo "::warning::Failed to create Honeycomb release marker (publish succeeded regardless)"
+            exit 0
           fi
+
+          body=$(jq -n --arg msg "$msg" --arg url "$url" --argjson start "$start_time" \
+            '{message: $msg, type: "deploy", url: $url, start_time: $start}')
+          "${curl[@]}" -X POST "${api}" -d "${body}"
+          echo "Created release marker for ${TAG}"
 
   notify-failure:
     name: Notify Release Failure


### PR DESCRIPTION
Adds an optional `honeycomb_api_key` secret to the classic buildpack publish workflow. When a caller passes it, a best-effort, idempotent marker is posted to the Honeycomb `builds` dataset on a successful **production** publish.

## What

- New optional `honeycomb_api_key` secret on `_classic-buildpack-publish.yml`'s `workflow_call` interface.
- A new **Post Honeycomb release marker** step appended after *Create GitHub Release*.

## Behavior

- **Opt-in / no-op:** skipped entirely when the secret isn't passed, so other language teams are unaffected.
- **Production-only:** gated on `env.MODE == 'production'` — QA/staging publishes don't post markers.
- **Idempotent (create-or-update):** dedups on the release URL, so re-running an idempotent publish updates the existing marker instead of stacking duplicates — matching the rest of this workflow.
- **Best-effort:** every API call ends in `|| echo "::warning::..."` and never exits non-zero; a Honeycomb outage can't fail an already-successful publish.

The dataset slug `builds` is hardcoded (shared by all classic buildpacks, gated by the API key, not sensitive). Only the API key is a secret.

W-22846373