### PR TITLE
Add publish notifications to the classic buildpack release workflow

### DIFF
--- a/.github/workflows/_classic-buildpack-publish.yml
+++ b/.github/workflows/_classic-buildpack-publish.yml
@@ -12,22 +12,29 @@ on:
         type: boolean
         required: false
         default: false
+      app_id:
+        description: Application ID of the GitHub application (e.g. the Linguist App) used to comment on the prepare PR and author the GitHub Release.
+        type: string
+        required: true
     secrets:
-      SLACK_WEBHOOK_URL:
+      app_private_key:
+        description: Private key of the GitHub application (e.g. the Linguist App).
+        required: true
+      slack_webhook_url:
         description: >-
-          Slack Workflow Builder webhook URL for #heroku-languages-ops. When set, a message
-          is posted if a production publish fails. Omit to disable (no-op for callers that
-          don't opt in).
-        required: false
+          Slack Workflow Builder webhook URL for #heroku-languages-ops. A message is posted
+          here if a production publish fails.
+        required: true
 
 # Full set of permissions the CALLING workflow must grant — a reusable workflow's GITHUB_TOKEN
 # is capped by what the caller provides. Each job below narrows to only what it needs via its
-# own `permissions:` block (the actual enforcement): `publish` never carries `pull-requests`,
-# and the notify jobs never carry `id-token`/`contents`.
+# own `permissions:` block (the actual enforcement). PR comments and the GitHub Release are
+# authored by the Linguist GitHub App token (minted per-job from `app_id`/`app_private_key`),
+# matching the CNB release automation — so the notify jobs need no GITHUB_TOKEN scopes at all,
+# and `publish` only needs `id-token` (OIDC mint) plus `contents` (push the version tag).
 permissions:
   id-token: write
   contents: write
-  pull-requests: write
 
 # Serialize publishes per buildpack so two rapid prepare-release merges (or a re-run racing a
 # fresh trigger) queue rather than racing the pre-flight check and the tag/registry/release
@@ -55,22 +62,27 @@ jobs:
       github.event_name == 'pull_request'
       && github.event.pull_request.merged == true
       && !inputs.qa
-    runs-on: ubuntu-24.04
-    permissions:
-      pull-requests: write     # comment on the triggering prepare-release PR
+    # Runs on the IP-allowlisted runner because the Linguist App token mint hits the heroku
+    # org's IP allow list, which GitHub-hosted runners aren't on. The comment is authored by
+    # the App token (not github.token), so the job needs no GITHUB_TOKEN scopes of its own.
+    runs-on: pub-hk-ubuntu-24.04-ip
+    permissions: {}
     steps:
+      - name: Get token for prepare PR comment
+        uses: actions/create-github-app-token@v3
+        id: comment-token
+        with:
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.app_private_key }}
+
       - name: Comment on prepare PR
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.comment-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          BUILDPACK_ID: ${{ inputs.buildpack_id }}
-          REPO: ${{ github.repository }}
-          RUN_ID: ${{ github.run_id }}
-          SERVER_URL: ${{ github.server_url }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          run_url="${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}"
-          gh pr comment "$PR_NUMBER" --body "📦 Publishing \`${BUILDPACK_ID}\` — workflow started: $run_url"
+          gh pr comment "$PR_NUMBER" --body "Release workflow started: $RUN_URL"
 
   publish:
     name: Publish
@@ -694,10 +706,20 @@ jobs:
           echo "The publish may still complete. Re-run this workflow to check (idempotent recovery)." >> "${GITHUB_STEP_SUMMARY}"
           exit 1
 
+      # Author the Release as the Linguist App. Minted here in the publish job, which already
+      # runs on the IP-allowlisted runner the App token mint requires.
+      - name: Get token for GitHub Release
+        if: steps.preflight.outputs.release_exists != 'true'
+        uses: actions/create-github-app-token@v3
+        id: release-token
+        with:
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.app_private_key }}
+
       - name: Create GitHub Release
         if: steps.preflight.outputs.release_exists != 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}
           TAG: ${{ steps.tag.outputs.name }}
           CHANGES: ${{ steps.tag.outputs.changes }}
         run: |
@@ -734,36 +756,38 @@ jobs:
     name: Notify Publish Failure
     needs: [publish]
     # `failure()` here is scoped to `needs` (the publish job). A skipped publish (its `if:`
-    # evaluated false) yields failure() == false, so no spurious "failed" comment fires.
-    if: failure()
-    runs-on: ubuntu-24.04
-    permissions:
-      pull-requests: write     # comment on the triggering prepare-release PR
+    # evaluated false) yields failure() == false, so no spurious "failed" notification fires.
+    # Notifications are only for the real release path: a merged prepare PR. Manual
+    # `workflow_dispatch` runs are for testing and stay silent, and QA runs never notify — so
+    # both gates live here rather than being repeated on every step below.
+    if: failure() && github.event_name == 'pull_request' && !inputs.qa
+    # Runs on the IP-allowlisted runner because the Linguist App token mint hits the heroku
+    # org's IP allow list. The comment is authored by the App token, so no GITHUB_TOKEN scopes.
+    runs-on: pub-hk-ubuntu-24.04-ip
+    permissions: {}
     env:
-      MODE: ${{ inputs.qa && 'qa' || 'production' }}
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      # Secrets can't be referenced in an `if:`, so mirror the webhook to env and test it there.
+      SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_url }}
     steps:
+      - name: Get token for prepare PR comment
+        uses: actions/create-github-app-token@v3
+        id: comment-token
+        with:
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.app_private_key }}
+
       - name: Comment failure on prepare PR
-        if: github.event_name == 'pull_request' && !inputs.qa
-        # Best-effort: a transient PR-comment failure must not abort the job before the more
-        # important production Slack alert (next step) gets a chance to fire.
-        continue-on-error: true
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.comment-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          BUILDPACK_ID: ${{ inputs.buildpack_id }}
-          REPO: ${{ github.repository }}
-          RUN_ID: ${{ github.run_id }}
-          SERVER_URL: ${{ github.server_url }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          run_url="${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}"
-          gh pr comment "$PR_NUMBER" --body "❌ Publish of \`${BUILDPACK_ID}\` failed — see $run_url"
+          gh pr comment "$PR_NUMBER" --body "Release workflow finished with failures — see the workflow run at $RUN_URL"
 
       - name: Notify Slack
-        # Production failures only, and only when the caller opted in by passing the webhook.
-        # Secrets can't be referenced in `if:`, so the URL is mirrored to env and tested there.
-        if: env.MODE == 'production' && env.SLACK_WEBHOOK_URL
+        # `always()` so that a failed comment step doesn't block the slack notification.
+        if: always()
         env:
           BUILDPACK_ID: ${{ inputs.buildpack_id }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/_classic-buildpack-publish.yml
+++ b/.github/workflows/_classic-buildpack-publish.yml
@@ -52,7 +52,7 @@ defaults:
 
 jobs:
   notify-start:
-    name: Notify Publish Started
+    name: Notify Release Started
     # Only the merged "Prepare release" PR has a thread to comment on, and that trigger is
     # always production. The `merged == true` guard mirrors the publish job's universal
     # precondition so a non-merge pull_request event (opened/synchronize/closed-without-merge)
@@ -753,7 +753,7 @@ jobs:
           fi
 
   notify-failure:
-    name: Notify Publish Failure
+    name: Notify Release Failure
     needs: [publish]
     # `failure()` here is scoped to `needs` (the publish job). A skipped publish (its `if:`
     # evaluated false) yields failure() == false, so no spurious "failed" notification fires.

--- a/.github/workflows/_classic-buildpack-publish.yml
+++ b/.github/workflows/_classic-buildpack-publish.yml
@@ -20,9 +20,14 @@ on:
           don't opt in).
         required: false
 
+# Full set of permissions the CALLING workflow must grant — a reusable workflow's GITHUB_TOKEN
+# is capped by what the caller provides. Each job below narrows to only what it needs via its
+# own `permissions:` block (the actual enforcement): `publish` never carries `pull-requests`,
+# and the notify jobs never carry `id-token`/`contents`.
 permissions:
   id-token: write
   contents: write
+  pull-requests: write
 
 # Serialize publishes per buildpack so two rapid prepare-release merges (or a re-run racing a
 # fresh trigger) queue rather than racing the pre-flight check and the tag/registry/release
@@ -41,6 +46,9 @@ defaults:
 jobs:
   publish:
     name: Publish
+    permissions:
+      id-token: write     # OIDC token mint for the buildpack registry
+      contents: write     # push the version tag + create the GitHub Release
     # QA mode bypasses the default-branch guard so staging publishes can be exercised from any
     # ref. Privilege escalation is bounded by the registry's OIDC trust policy (which pins
     # repo + workflow path) — this guard is a convenience, not the security boundary.

--- a/.github/workflows/_classic-buildpack-publish.yml
+++ b/.github/workflows/_classic-buildpack-publish.yml
@@ -13,7 +13,7 @@ on:
         required: false
         default: false
     secrets:
-      slack_webhook_url:
+      SLACK_WEBHOOK_URL:
         description: >-
           Slack Workflow Builder webhook URL for #heroku-languages-ops. When set, a message
           is posted if a production publish fails. Omit to disable (no-op for callers that
@@ -60,9 +60,12 @@ jobs:
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           BUILDPACK_ID: ${{ inputs.buildpack_id }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          SERVER_URL: ${{ github.server_url }}
         run: |
-          gh pr comment "$PR_NUMBER" --body "📦 Publishing \`${BUILDPACK_ID}\` — workflow started: $RUN_URL"
+          run_url="${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}"
+          gh pr comment "$PR_NUMBER" --body "📦 Publishing \`${BUILDPACK_ID}\` — workflow started: $run_url"
 
   publish:
     name: Publish
@@ -721,3 +724,50 @@ jobs:
             } >> "${GITHUB_STEP_SUMMARY}"
             exit 1
           fi
+
+  notify-failure:
+    name: Notify Publish Failure
+    needs: [publish]
+    # `failure()` here is scoped to `needs` (the publish job). A skipped publish (its `if:`
+    # evaluated false) yields failure() == false, so no spurious "failed" comment fires.
+    if: failure()
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write     # comment on the triggering prepare-release PR
+    env:
+      MODE: ${{ inputs.qa && 'qa' || 'production' }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    steps:
+      - name: Comment failure on prepare PR
+        if: github.event_name == 'pull_request' && !inputs.qa
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BUILDPACK_ID: ${{ inputs.buildpack_id }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          SERVER_URL: ${{ github.server_url }}
+        run: |
+          run_url="${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}"
+          gh pr comment "$PR_NUMBER" --body "❌ Publish of \`${BUILDPACK_ID}\` failed — see $run_url"
+
+      - name: Notify Slack
+        # Production failures only, and only when the caller opted in by passing the webhook.
+        # Secrets can't be referenced in `if:`, so the URL is mirrored to env and tested there.
+        if: env.MODE == 'production' && env.SLACK_WEBHOOK_URL
+        env:
+          BUILDPACK_ID: ${{ inputs.buildpack_id }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          SERVER_URL: ${{ github.server_url }}
+        run: |
+          # Build the JSON with jq from shell variables rather than splicing values into a string
+          # literal, so buildpack_id can't break out of the payload.
+          message="Classic buildpack publish failed: ${BUILDPACK_ID}"
+          run_url="${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}"
+          curl -sS --retry 3 --retry-all-errors --max-time 30 \
+            -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-type: application/json' \
+            --data "$(jq -n --arg msg "$message" --arg url "$run_url" \
+              '{message: $msg, run_url: $url}')"

--- a/.github/workflows/_classic-buildpack-publish.yml
+++ b/.github/workflows/_classic-buildpack-publish.yml
@@ -47,9 +47,14 @@ jobs:
   notify-start:
     name: Notify Publish Started
     # Only the merged "Prepare release" PR has a thread to comment on, and that trigger is
-    # always production. The explicit `!inputs.qa` is defensive against any future QA path
-    # that might ride a pull_request event.
-    if: github.event_name == 'pull_request' && !inputs.qa
+    # always production. The `merged == true` guard mirrors the publish job's universal
+    # precondition so a non-merge pull_request event (opened/synchronize/closed-without-merge)
+    # can't post a false "publishing started" comment while publish itself skips. The explicit
+    # `!inputs.qa` is defensive against any future QA path that might ride a pull_request event.
+    if: |
+      github.event_name == 'pull_request'
+      && github.event.pull_request.merged == true
+      && !inputs.qa
     runs-on: ubuntu-24.04
     permissions:
       pull-requests: write     # comment on the triggering prepare-release PR
@@ -740,6 +745,9 @@ jobs:
     steps:
       - name: Comment failure on prepare PR
         if: github.event_name == 'pull_request' && !inputs.qa
+        # Best-effort: a transient PR-comment failure must not abort the job before the more
+        # important production Slack alert (next step) gets a chance to fire.
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
@@ -766,7 +774,10 @@ jobs:
           # literal, so buildpack_id can't break out of the payload.
           message="Classic buildpack publish failed: ${BUILDPACK_ID}"
           run_url="${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}"
-          curl -sS --retry 3 --retry-all-errors --max-time 30 \
+          # --fail-with-body makes curl exit non-zero on an HTTP 4xx/5xx (e.g. a revoked webhook
+          # returning 404 no_service) instead of silently "succeeding" — a dead webhook should
+          # surface as a failed step rather than a missed alert.
+          curl -sS --fail-with-body --retry 3 --retry-all-errors --max-time 30 \
             -X POST "$SLACK_WEBHOOK_URL" \
             -H 'Content-type: application/json' \
             --data "$(jq -n --arg msg "$message" --arg url "$run_url" \

--- a/.github/workflows/_classic-buildpack-publish.yml
+++ b/.github/workflows/_classic-buildpack-publish.yml
@@ -12,6 +12,13 @@ on:
         type: boolean
         required: false
         default: false
+    secrets:
+      slack_webhook_url:
+        description: >-
+          Slack Workflow Builder webhook URL for #heroku-languages-ops. When set, a message
+          is posted if a production publish fails. Omit to disable (no-op for callers that
+          don't opt in).
+        required: false
 
 permissions:
   id-token: write

--- a/.github/workflows/_classic-buildpack-publish.yml
+++ b/.github/workflows/_classic-buildpack-publish.yml
@@ -44,6 +44,26 @@ defaults:
     shell: bash
 
 jobs:
+  notify-start:
+    name: Notify Publish Started
+    # Only the merged "Prepare release" PR has a thread to comment on, and that trigger is
+    # always production. The explicit `!inputs.qa` is defensive against any future QA path
+    # that might ride a pull_request event.
+    if: github.event_name == 'pull_request' && !inputs.qa
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write     # comment on the triggering prepare-release PR
+    steps:
+      - name: Comment on prepare PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BUILDPACK_ID: ${{ inputs.buildpack_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh pr comment "$PR_NUMBER" --body "📦 Publishing \`${BUILDPACK_ID}\` — workflow started: $RUN_URL"
+
   publish:
     name: Publish
     permissions:


### PR DESCRIPTION
## Summary

Surfaces classic-buildpack publish progress and outcome outside the Actions run, so a failed publish can't go unnoticed. Brings the classic pipeline to parity with the CNB `_buildpacks-release.yml` `notify-start`/`notify-failure` pattern.

Adds two sibling jobs to the shared `_classic-buildpack-publish.yml`:

- **`notify-start`** — comments `Release workflow started: <run-url>` on the triggering "Prepare release" PR. Gated to merged production PRs (`pull_request` + `merged == true` + `!qa`), mirroring the publish job's own precondition.
- **`notify-failure`** (`needs: [publish]`, `if: failure()`) — comments `Release workflow finished with failures …` on the PR, **and** posts to `#heroku-languages-ops` via a Slack Workflow Builder webhook. Both notifications fire for **production prepare-PR failures only** — manual `workflow_dispatch` runs are for testing and stay silent.

Supporting changes:

- PR comments and the GitHub Release are now authored by the **Linguist GitHub App** (minted per-job from `app_id`/`app_private_key`), rather than the generic `github-actions` user — matching the CNB automation. Both notify jobs run on the IP-allowlisted runner (required for the App token mint) with `permissions: {}`.
- The version tag push stays on `github.token` (`contents: write`): a lightweight tag carries no identity, and pushing it via the App token would risk triggering downstream `on: push: tags` workflows.
- **Permissions restructure** — the workflow-level block now grants only `id-token` + `contents` (the union the `publish` job needs); the notify jobs need no `GITHUB_TOKEN` scopes.

## Caller changes (separate, not in this PR)

To adopt this, a classic buildpack's `release.yml` must pass three new required parameters: the `app_id` input, the `app_private_key` secret, and the `slack_webhook_url` secret. No `pull-requests: write` grant is needed (the notify jobs author comments via the App token). The `heroku-buildpack-nodejs` caller update + Slack webhook provisioning are tracked separately and must be coordinated with this change.

[W-22900983](https://gus.lightning.force.com/a07EE00002bkd3nYAA)
