### PR TITLE
Loosen libcnb version pins so Dependabot can update them

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,9 +36,12 @@ clap = { version = "4", default-features = false, features = [
 fastrand = "2"
 ignore = "0.4"
 indexmap = "2"
-libcnb-common = "=0.30.4"
-libcnb-data = "=0.30.4"
-libcnb-package = "=0.30.4"
+# Can't use exact `=` versions here: these crates pin each other with exact
+# requirements, so Dependabot can't bump one without the others and gives up
+# with "No update possible", opening no PR at all.
+libcnb-common = "0.30"
+libcnb-data = "0.30"
+libcnb-package = "0.30"
 markdown = "1"
 regex = "1"
 semver = "1"


### PR DESCRIPTION
The `libcnb-common`, `libcnb-data` and `libcnb-package` crates pin each other with exact `=` requirements, so when all three are also pinned to an exact version here, Dependabot can't bump any one of them without the others and gives up with "No update possible", opening no PR at all. This is why no `libcnb` 0.31.0 PR was created despite the release.

This only affects this repo and not the CNBs, since this repo depends directly on the lower-level `libcnb-common`/`libcnb-data`/`libcnb-package` crates, whereas the CNBs depend on the higher-level `libcnb`/`libcnb-test`/`libherokubuildpack` crates.

GUS-W-23329202.