### PR TITLE
Replace deprecated `app-id` input with `client-id`

### DIFF
--- a/.github/workflows/_buildpacks-prepare-release.yml
+++ b/.github/workflows/_buildpacks-prepare-release.yml
@@ -74,7 +74,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: generate-token
         with:
-          app-id: ${{ inputs.app_id }}
+          client-id: ${{ inputs.app_id }}
           private-key: ${{ secrets.app_private_key }}
 
       - name: Checkout

--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -76,7 +76,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: comment-token
         with:
-          app-id: ${{ inputs.app_id }}
+          client-id: ${{ inputs.app_id }}
           private-key: ${{ secrets.app_private_key }}
 
       - name: Notify release started on prepare PR
@@ -371,7 +371,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: generate-token
         with:
-          app-id: ${{ inputs.app_id }}
+          client-id: ${{ inputs.app_id }}
           private-key: ${{ secrets.app_private_key }}
 
       - name: Check if release exists
@@ -439,7 +439,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: generate-token
         with:
-          app-id: ${{ inputs.app_id }}
+          client-id: ${{ inputs.app_id }}
           private-key: ${{ secrets.app_private_key }}
           owner: heroku
           repositories: cnb-builder-images
@@ -515,7 +515,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: comment-token
         with:
-          app-id: ${{ inputs.app_id }}
+          client-id: ${{ inputs.app_id }}
           private-key: ${{ secrets.app_private_key }}
 
       - name: Notify builder PR opened on prepare PR
@@ -540,7 +540,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: comment-token
         with:
-          app-id: ${{ inputs.app_id }}
+          client-id: ${{ inputs.app_id }}
           private-key: ${{ secrets.app_private_key }}
 
       - name: Notify release failure on prepare PR

--- a/.github/workflows/_classic-buildpack-prepare-release.yml
+++ b/.github/workflows/_classic-buildpack-prepare-release.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: generate-token
         with:
-          app-id: ${{ vars.LINGUIST_GH_APP_ID }}
+          client-id: ${{ vars.LINGUIST_GH_APP_ID }}
           # Note: The calling workflow must enable secrets inheritance for this variable to be accessible:
           # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idsecretsinherit
           private-key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}

--- a/.github/workflows/_classic-buildpack-publish.yml
+++ b/.github/workflows/_classic-buildpack-publish.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: comment-token
         with:
-          app-id: ${{ inputs.app_id }}
+          client-id: ${{ inputs.app_id }}
           private-key: ${{ secrets.app_private_key }}
 
       - name: Comment on prepare PR
@@ -719,7 +719,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: release-token
         with:
-          app-id: ${{ inputs.app_id }}
+          client-id: ${{ inputs.app_id }}
           private-key: ${{ secrets.app_private_key }}
 
       - name: Create GitHub Release
@@ -818,7 +818,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: comment-token
         with:
-          app-id: ${{ inputs.app_id }}
+          client-id: ${{ inputs.app_id }}
           private-key: ${{ secrets.app_private_key }}
 
       - name: Comment failure on prepare PR

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: generate-token
         with:
-          app-id: ${{ vars.LINGUIST_GH_APP_ID }}
+          client-id: ${{ vars.LINGUIST_GH_APP_ID }}
           private-key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}
 
       - name: Checkout


### PR DESCRIPTION
`actions/create-github-app-token@v3` deprecated its `app-id` input in favour of `client-id`, emitting a deprecation warning in workflow runs:

```
Input 'app-id' has been deprecated with message: Use 'client-id' instead.
```

Example run showing the warning:
https://github.com/heroku/buildpacks-deb-packages/actions/runs/28865909856

Upstream deprecation (create-github-app-token v3.1.0):
https://github.com/actions/create-github-app-token/releases/tag/v3.1.0

Rename `app-id:` to `client-id:` at all `create-github-app-token` call sites across the reusable release/publish workflows.

This is a pure key rename: the action reads `client-id` (falling back to the deprecated `app-id`) and passes the value straight through as the app id, which accepts either a numeric App ID or a Client ID. The existing `LINGUIST_GH_APP_ID` variable and `app_id` workflow inputs keep working unchanged.

GUS-W-23346719.