### PR TITLE
Grant actions: write scope to compile job for cache/save@v6

### DIFF
--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -91,6 +91,11 @@ jobs:
   compile:
     name: Compile Buildpacks
     runs-on: ubuntu-24.04
+    # Required by actions/cache/save@v6: writing to the GitHub Actions cache
+    # requires the `actions: write` scope on the workflow token. Reading from
+    # the cache does not, so publish jobs keep the top-level `permissions: {}`.
+    permissions:
+      actions: write
     outputs:
       buildpacks: ${{ steps.generate-buildpack-matrix.outputs.buildpacks }}
       version: ${{ steps.generate-buildpack-matrix.outputs.version }}


### PR DESCRIPTION
Every release fails at cache handoff. The caller workflows set `permissions: {}`, and `actions/cache/save@v6` needs the `actions: write` scope to write to the cache. The compile job's save fails with `cache write denied: token has no writable scopes`, and every downstream publish job fails restore with `fail-on-cache-miss`.

This came in with #374 (v5 → v6). v5 relied on the legacy cache backend which did not require the scope; v6 fully depends on the v2 backend which does.

Scope is granted only to the `compile` job. Restore does not need write, so every publish job continues to inherit the top-level `permissions: {}`.

Longer term we should probably migrate the intra-run buildpack handoff from `actions/cache` to `actions/upload-artifact` / `download-artifact`, which is the intended primitive for passing files between jobs in the same run and needs no elevated scope. That's a bigger change though — this PR just aims to restore our ability to release.

Example failure: https://github.com/heroku/buildpacks-jvm/actions/runs/29342731996