### PR TITLE
Pass compiled buildpacks between release jobs via artifacts

### DIFF
--- a/.github/workflows/_buildpacks-release.yml
+++ b/.github/workflows/_buildpacks-release.yml
@@ -198,11 +198,23 @@ jobs:
         id: generate-changelog
         run: actions generate-changelog --version ${{ steps.generate-buildpack-matrix.outputs.version }}
 
-      - name: Cache buildpacks
-        uses: actions/cache/save@v6
+      # Hand the compiled buildpacks to the publish jobs as an artifact. This
+      # is a within-run transfer, and an artifact upload works regardless of
+      # how the caller triggers this workflow, whereas an Actions cache write
+      # does not: GitHub's 2026-06-26 read-only-cache-for-untrusted-triggers
+      # change denies cache writes on untrusted triggers such as
+      # `pull_request` (the auto-release-on-merge path). `if-no-files-found:
+      # error` surfaces a packaging failure in this job rather than downstream;
+      # `include-hidden-files` includes dotfiles in the upload. See
+      # heroku/languages-github-actions#383.
+      - name: Upload compiled buildpacks
+        uses: actions/upload-artifact@v7
         with:
-          key: ${{ github.run_id }}-compiled-buildpacks
+          name: compiled-buildpacks
           path: ${{ env.PACKAGE_DIR }}
+          if-no-files-found: error
+          include-hidden-files: true
+          retention-days: 1
 
   publish-docker:
     name: Publish → Docker - ${{ matrix.buildpack_id }}
@@ -223,14 +235,11 @@ jobs:
         with:
           submodules: true
 
-      - name: Restore buildpacks
-        uses: actions/cache/restore@v6
+      - name: Download compiled buildpacks
+        uses: actions/download-artifact@v8
         with:
-          fail-on-cache-miss: true
-          key: ${{ github.run_id }}-compiled-buildpacks
+          name: compiled-buildpacks
           path: ${{ env.PACKAGE_DIR }}
-        env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
 
       - name: Install Pack CLI
         uses: buildpacks/github-actions/setup-pack@c1c71086a0e89a65c04ea113390227fd7f05d9df # v6.0.0
@@ -344,14 +353,11 @@ jobs:
         with:
           submodules: true
 
-      - name: Restore buildpacks
-        uses: actions/cache/restore@v6
+      - name: Download compiled buildpacks
+        uses: actions/download-artifact@v8
         with:
-          fail-on-cache-miss: true
-          key: ${{ github.run_id }}-compiled-buildpacks
+          name: compiled-buildpacks
           path: ${{ env.PACKAGE_DIR }}
-        env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
 
       - name: Install Pack CLI
         uses: buildpacks/github-actions/setup-pack@c1c71086a0e89a65c04ea113390227fd7f05d9df # v6.0.0


### PR DESCRIPTION
## Summary

- Passes the compiled buildpacks from the `compile` job to the `publish-docker` / `publish-github` jobs via `actions/upload-artifact` + `download-artifact` instead of `actions/cache`.
- Fixes the auto-release-on-merge path, which has been broken since GitHub's [2026-06-26 read-only-cache-for-untrusted-triggers change](https://github.blog/changelog/2026-06-26-read-only-actions-cache-for-untrusted-triggers/): that change issues read-only cache tokens on `pull_request`-triggered runs, and this workflow's release trigger is `pull_request: [closed]`. The `compile` job's `cache/save` write is denied (`cache write denied: token has no writable scopes`) but only *warns*, so `compile` stays green — the failure surfaces one job later as a `fail-on-cache-miss` restore error in the publish jobs.

## Why artifacts (not e.g. granting `actions: write`)

The read-only restriction is imposed by the trigger's trust level, not the workflow token's permission scope, so granting `actions: write` can't fix it (see the closed #386). The `compile → publish` handoff is an intra-run transfer — the cache was keyed on `github.run_id` and never reused across runs — which is exactly what artifacts are for. Artifact upload/download uses the Actions runtime token, which is unaffected by the cache change, so the top-level `permissions: {}` stays untouched.

## Notes

- `if-no-files-found: error` surfaces a packaging failure in `compile` instead of one job downstream (the debugging pain called out in the issue); `download-artifact` already fails on a missing artifact, replacing the old `fail-on-cache-miss: true`.
- `include-hidden-files: true` preserves dotfiles the cache would have captured; `retention-days: 1` keeps storage minimal since the artifact is only needed within the run.
- `Swatinem/rust-cache` is deliberately left on `actions/cache` — it's a genuine cross-run build cache, and a denied write there is a harmless slower compile, not a failure. This means the Rust cache still won't be written on `pull_request` runs; fully restoring it would require the separate `push`-trigger fix from the issue.
- Verified downstream: buildpacks-go's failed release ([run 30840863251](https://github.com/heroku/buildpacks-go/actions/runs/30840863251)) exhibited exactly this cache-write-denied → restore-miss chain, while the manual `workflow_dispatch` recovery ([run 30842667453](https://github.com/heroku/buildpacks-go/actions/runs/30842667453)) succeeded because `workflow_dispatch` is a trusted trigger.

See #383 for additional context.

GUS-W-23703633
